### PR TITLE
Header ext padding fix

### DIFF
--- a/src/main/kotlin/org/jitsi/rtp/rtp/RtpPacket.kt
+++ b/src/main/kotlin/org/jitsi/rtp/rtp/RtpPacket.kt
@@ -21,6 +21,7 @@ import org.jitsi.rtp.extensions.bytearray.putShort
 import org.jitsi.rtp.rtp.header_extensions.HeaderExtensionHelpers
 import org.jitsi.rtp.util.BufferPool
 import org.jitsi.rtp.util.getByteAsInt
+import org.jitsi.rtp.util.isPadding
 import kotlin.experimental.or
 
 /**
@@ -374,6 +375,11 @@ open class RtpPacket(
         val currHeaderExtension: HeaderExtension = HeaderExtension()
 
         override fun hasNext(): Boolean {
+            // Consume any padding
+            while (remainingLength > 0 && buffer.get(nextOffset).isPadding()) {
+                nextOffset++
+                remainingLength--
+            }
             if (remainingLength <= 0 || nextOffset < 0) {
                 return false
             }

--- a/src/main/kotlin/org/jitsi/rtp/rtp/RtpPacket.kt
+++ b/src/main/kotlin/org/jitsi/rtp/rtp/RtpPacket.kt
@@ -117,7 +117,7 @@ open class RtpPacket(
         }
 
     private val _headerExtensions: HeaderExtensions = HeaderExtensions()
-    val headerExtensions: HeaderExtensions
+    private val headerExtensions: HeaderExtensions
         get() {
             _headerExtensions.reset()
             return _headerExtensions

--- a/src/main/kotlin/org/jitsi/rtp/util/RtpUtils.kt
+++ b/src/main/kotlin/org/jitsi/rtp/util/RtpUtils.kt
@@ -89,6 +89,9 @@ class RtpUtils {
     }
 }
 
+fun Int.isPadding(): Boolean = this.toByte().isPadding()
+fun Byte.isPadding(): Boolean = this == 0x00.toByte()
+
 /**
  * Returns true if the RTP sequence number represented by [this] represents a more recent RTP packet than the one
  * represented by [otherSeqNum]


### PR DESCRIPTION
we had an issue parsing header extensions when there was padding in between the extensions themselves.  for certain padding values (specifically 2 bytes of padding) this was "ok": we read the length of 1 but then added the header ext size (2) to the overall length, so we parsed it as an extension with id 0 and data 0, but for other values of padding (1 or 3 bytes) we would've had a problem.