### PR TITLE
Revert "squash: Adds the whole payload to the packet payload verifica…

### DIFF
--- a/src/main/kotlin/org/jitsi/rtp/Packet.kt
+++ b/src/main/kotlin/org/jitsi/rtp/Packet.kt
@@ -16,7 +16,7 @@
 
 package org.jitsi.rtp
 
-import org.jitsi.rtp.extensions.bytearray.toHex
+import org.jitsi.rtp.extensions.bytearray.hashCodeOfSegment
 import java.util.function.Predicate
 
 // TODO move
@@ -41,5 +41,5 @@ abstract class Packet(
      * Different subclasses of [Packet] will have different notions of "payload", and they need to
      */
     open val payloadVerification: String
-        get() = "len=$length payload=${buffer.toHex(offset, length)}"
+        get() = "len=$length hashCode=${buffer.hashCodeOfSegment(offset, offset + length)}"
 }

--- a/src/main/kotlin/org/jitsi/rtp/extensions/bytearray/ByteArrayExtensions.kt
+++ b/src/main/kotlin/org/jitsi/rtp/extensions/bytearray/ByteArrayExtensions.kt
@@ -160,6 +160,17 @@ fun ByteArray.toHex(offset: Int = 0, length: Int = (size - offset)): String {
     return result.toString()
 }
 
+/**
+ * Returns the hash code of the segment of this [ByteArray] starting at 'start' and ending in 'end' (exclusive).
+ */
+fun ByteArray.hashCodeOfSegment(start: Int, end: Int): Int {
+    var result = 1
+    for (i in start.coerceIn(0, size) until end.coerceIn(0, size)) {
+        result = 31 * result + this[i]
+    }
+    return result
+}
+
 class ByteArrayUtils {
     companion object {
         val emptyByteArray = BufferPool.getArray(0)

--- a/src/main/kotlin/org/jitsi/rtp/rtp/RtpPacket.kt
+++ b/src/main/kotlin/org/jitsi/rtp/rtp/RtpPacket.kt
@@ -17,8 +17,8 @@
 package org.jitsi.rtp.rtp
 
 import org.jitsi.rtp.Packet
+import org.jitsi.rtp.extensions.bytearray.hashCodeOfSegment
 import org.jitsi.rtp.extensions.bytearray.putShort
-import org.jitsi.rtp.extensions.bytearray.toHex
 import org.jitsi.rtp.rtp.header_extensions.HeaderExtensionHelpers
 import org.jitsi.rtp.util.BufferPool
 import org.jitsi.rtp.util.getByteAsInt
@@ -129,7 +129,7 @@ open class RtpPacket(
      * For [RtpPacket] the payload is everything after the RTP Header.
      */
     override val payloadVerification: String
-        get() = "type=RtpPacket len=$payloadLength payload=${buffer.toHex(payloadOffset, payloadLength)}"
+        get() = "type=RtpPacket len=$payloadLength hashCode=${buffer.hashCodeOfSegment(payloadOffset, payloadOffset + payloadLength)}"
 
     fun getHeaderExtension(extensionId: Int): HeaderExtension? {
         headerExtensions.forEach { ext ->


### PR DESCRIPTION
…tion string."

Uses just the hash code for payload verification. On a large test call we easily overloaded the machine. Testing with a 3-way call on my dev machine I see an average of 36% cpu usage with full payload vs 13% with just the hash code