### PR TITLE
Uses ByteArrayBuffer from jitsi-utils

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>org.jitsi</groupId>
             <artifactId>jitsi-utils</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>1.0-20190723.110846-12</version>
         </dependency>
 
         <!--Testing dependencies-->

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,11 @@
             <artifactId>kotlin-unsigned</artifactId>
             <version>v3.1.3</version>
         </dependency>
+        <dependency>
+            <groupId>org.jitsi</groupId>
+            <artifactId>jitsi-utils</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
 
         <!--Testing dependencies-->
         <dependency>

--- a/src/main/kotlin/org/jitsi/rtp/ByteArrayBufferImpl.java
+++ b/src/main/kotlin/org/jitsi/rtp/ByteArrayBufferImpl.java
@@ -17,9 +17,11 @@
 package org.jitsi.rtp;
 
 import org.jitsi.rtp.util.*;
+import org.jitsi.utils.*;
 
 //TODO documentation
-public abstract class ByteArrayBuffer
+public abstract class ByteArrayBufferImpl
+    implements ByteArrayBuffer
 {
     private static final char[] HEX_CHARS = "0123456789ABCDEF".toCharArray();
 
@@ -29,14 +31,14 @@ public abstract class ByteArrayBuffer
 
     public int length;
 
-    public ByteArrayBuffer(byte[] buffer, int offset, int length)
+    public ByteArrayBufferImpl(byte[] buffer, int offset, int length)
     {
         this.buffer = buffer;
         this.offset = offset;
         this.length = length;
     }
 
-    public ByteArrayBuffer()
+    public ByteArrayBufferImpl()
     {
         this.buffer = new byte[0];
         this.offset = 0;
@@ -111,7 +113,7 @@ public abstract class ByteArrayBuffer
 
 
     /**
-     * Grows the internal buffer of this {@code ByteArrayBuffer}.
+     * Grows the internal buffer of this {@code ByteArrayBufferImpl}.
      *
      * This will change the data buffer of this packet but not the length of the
      * valid data. Use this to grow the internal buffer to avoid buffer
@@ -152,6 +154,17 @@ public abstract class ByteArrayBuffer
             this.length = 0;
     }
 
+    /**
+     * Creates a clone of this buffer. The underlying byte[] has the same size
+     * as our byte[], but we only copy the data that this {@link ByteArrayBufferImpl}
+     * represents.
+     */
+    protected byte[] cloneBuffer()
+    {
+        byte[] clone = BufferPool.Companion.getGetArray().invoke(buffer.length);
+        System.arraycopy(buffer, offset, clone, offset, length);
+        return clone;
+    }
 
 
     /**
@@ -183,5 +196,11 @@ public abstract class ByteArrayBuffer
         }
 
         return sb.toString();
+    }
+
+    @Override
+    public boolean isInvalid()
+    {
+        return false;
     }
 }

--- a/src/main/kotlin/org/jitsi/rtp/ByteArrayBufferImpl.java
+++ b/src/main/kotlin/org/jitsi/rtp/ByteArrayBufferImpl.java
@@ -23,7 +23,6 @@ import org.jitsi.utils.*;
 public abstract class ByteArrayBufferImpl
     implements ByteArrayBuffer
 {
-    private static final char[] HEX_CHARS = "0123456789ABCDEF".toCharArray();
 
     public byte[] buffer;
 
@@ -173,29 +172,6 @@ public abstract class ByteArrayBufferImpl
     public void setBuffer(byte[] buffer)
     {
         this.buffer = buffer;
-    }
-
-    public String toHex()
-    {
-        StringBuilder sb = new StringBuilder();
-        int position = 0;
-
-        for (int i = offset; i < (offset + length) && i < buffer.length; ++i)
-        {
-            int octet = buffer[i];
-            int firstIndex = (octet & 0xF0) >> 4;
-            int secondIndex = octet & 0x0F;
-            sb.append(HEX_CHARS[firstIndex]);
-            sb.append(HEX_CHARS[secondIndex]);
-            if ((position + 1) % 16 == 0) {
-                sb.append("\n");
-            } else if ((position + 1) % 4 == 0) {
-                sb.append(" ");
-            }
-            position++;
-        }
-
-        return sb.toString();
     }
 
     @Override

--- a/src/main/kotlin/org/jitsi/rtp/ByteArrayBufferImpl.java
+++ b/src/main/kotlin/org/jitsi/rtp/ByteArrayBufferImpl.java
@@ -154,19 +154,6 @@ public abstract class ByteArrayBufferImpl
     }
 
     /**
-     * Creates a clone of this buffer. The underlying byte[] has the same size
-     * as our byte[], but we only copy the data that this {@link ByteArrayBufferImpl}
-     * represents.
-     */
-    protected byte[] cloneBuffer()
-    {
-        byte[] clone = BufferPool.Companion.getGetArray().invoke(buffer.length);
-        System.arraycopy(buffer, offset, clone, offset, length);
-        return clone;
-    }
-
-
-    /**
      * @param buffer the buffer to set
      */
     public void setBuffer(byte[] buffer)

--- a/src/main/kotlin/org/jitsi/rtp/Packet.kt
+++ b/src/main/kotlin/org/jitsi/rtp/Packet.kt
@@ -23,7 +23,7 @@ abstract class Packet(
     buffer: ByteArray,
     offset: Int,
     length: Int
-) : ByteArrayBuffer(buffer, offset, length), Cloneable {
+) : ByteArrayBufferImpl(buffer, offset, length), Cloneable {
 
     inline fun <OtherType : Packet> toOtherType(otherTypeCreator: (ByteArray, Int, Int) -> OtherType): OtherType =
         otherTypeCreator(buffer, offset, length)

--- a/src/main/kotlin/org/jitsi/rtp/extensions/ByteArrayBuffer.kt
+++ b/src/main/kotlin/org/jitsi/rtp/extensions/ByteArrayBuffer.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright @ 2019 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jitsi.rtp.extensions
+
+import org.jitsi.utils.ByteArrayBuffer
+import java.lang.Integer.min
+
+fun ByteArrayBuffer.toHex(): String
+{
+    val HEX_CHARS = "0123456789ABCDEF"
+
+    val sb = StringBuilder()
+    for (i in offset until min(offset + length, buffer.size)) {
+        val octet: Int = buffer[i].toInt()
+        val firstIndex = (octet and 0xF0) shr 4
+        val secondIndex = octet and 0x0F
+        sb.append(HEX_CHARS[firstIndex])
+        sb.append(HEX_CHARS[secondIndex])
+        val position = i - offset
+        if ((position + 1) % 16 == 0) {
+            sb.append("\n")
+        } else if ((position + 1) % 4 == 0) {
+            sb.append(" ")
+        }
+    }
+
+    return sb.toString()
+}

--- a/src/main/kotlin/org/jitsi/rtp/util/SrtpUtils.kt
+++ b/src/main/kotlin/org/jitsi/rtp/util/SrtpUtils.kt
@@ -16,7 +16,7 @@
 
 package org.jitsi.rtp.util
 
-import org.jitsi.rtp.ByteArrayBuffer
+import org.jitsi.utils.ByteArrayBuffer
 import org.jitsi.rtp.extensions.bytearray.getInt
 
 class SrtpUtils {

--- a/src/test/java/org/jitsi/test_helpers/matchers/ByteArrayBuffer.kt
+++ b/src/test/java/org/jitsi/test_helpers/matchers/ByteArrayBuffer.kt
@@ -17,7 +17,8 @@ package org.jitsi.test_helpers.matchers
 
 import io.kotlintest.Matcher
 import io.kotlintest.Result
-import org.jitsi.rtp.ByteArrayBuffer
+import org.jitsi.rtp.extensions.toHex
+import org.jitsi.utils.ByteArrayBuffer
 
 fun ByteArrayBuffer.hasSameContentAs(other: ByteArrayBuffer): Boolean {
     if (other.length != length) {

--- a/src/test/java/org/jitsi/test_helpers/matchers/RtpPacket.kt
+++ b/src/test/java/org/jitsi/test_helpers/matchers/RtpPacket.kt
@@ -17,9 +17,10 @@ package org.jitsi.test_helpers.matchers
 
 import io.kotlintest.Matcher
 import io.kotlintest.Result
-import org.jitsi.rtp.ByteArrayBuffer
+import org.jitsi.rtp.extensions.toHex
 import org.jitsi.rtp.rtp.RtpHeader
 import org.jitsi.rtp.rtp.RtpPacket
+import org.jitsi.utils.ByteArrayBuffer
 
 fun RtpPacket.getPayload(): ByteArrayBuffer {
     return RtpPacket(buffer, payloadOffset, payloadLength)


### PR DESCRIPTION
Makes ByteArrayBuffer/Packet etc inherit from jitsi-utils' ByteArrayBuffer. This allows libjitsi's unmodified SRTP code to work with jitsi-rtp packets.