### PR TITLE
Add API reporting non-received packets in RtcpFbTccPacket.

### DIFF
--- a/src/main/kotlin/org/jitsi/rtp/rtcp/rtcpfb/transport_layer_fb/tcc/RtcpFbTccPacket.kt
+++ b/src/main/kotlin/org/jitsi/rtp/rtcp/rtcpfb/transport_layer_fb/tcc/RtcpFbTccPacket.kt
@@ -37,16 +37,18 @@ import org.jitsi.rtp.util.get3BytesAsInt
 import org.jitsi.rtp.util.getByteAsInt
 import org.jitsi.rtp.util.getShortAsInt
 
+open class PacketReport(val seqNum: Int) {
+    operator fun component1(): Int = seqNum
+}
+
+class UnreceivedPacketReport(seqNum: Int) : PacketReport(seqNum)
+
 // Size in bytes of a delta time in rtcp packet.
 // Valid values are 0 (packet wasn't received), 1 or 2.
 typealias DeltaSize = Int
 
-class ReceivedPacket(val seqNum: Int, val deltaTicks: Short, val received: Boolean = true) {
-    operator fun component1(): Int = seqNum
+class ReceivedPacketReport(seqNum: Int, val deltaTicks: Short) : PacketReport(seqNum) {
     operator fun component2(): Short = deltaTicks
-    operator fun component3(): Boolean = received
-
-    constructor(seqNum: Int) : this(seqNum, 0, false)
 }
 
 /**
@@ -81,7 +83,7 @@ class RtcpFbTccPacketBuilder(
     // The size of the entire packet, in bytes
     private var size_bytes_ = kTransportFeedbackHeaderSizeBytes
     private var last_timestamp_us_: Long = 0
-    private val packets_ = mutableListOf<ReceivedPacket>()
+    private val packets_ = mutableListOf<PacketReport>()
 
     fun SetBase(base_sequence: Int, ref_timestamp_us: Long) {
         base_seq_no_ = RtpSequenceNumber(base_sequence)
@@ -120,7 +122,7 @@ class RtcpFbTccPacketBuilder(
         if (!AddDeltaSize(delta_size))
             return false
 
-        packets_.add(ReceivedPacket(sequence_number.value, delta))
+        packets_.add(ReceivedPacketReport(sequence_number.value, delta))
         last_timestamp_us_ += delta * kDeltaScaleFactor
         size_bytes_ += delta_size
 
@@ -189,11 +191,13 @@ class RtcpFbTccPacketBuilder(
             currOffset += kChunkSizeBytes
         }
         packets_.forEach {
-            when (it.deltaTicks) {
-                in 0..0xFF -> buf[currOffset++] = it.deltaTicks.toByte()
-                else -> {
-                    buf.putShort(currOffset, it.deltaTicks)
-                    currOffset += 2
+            if (it is ReceivedPacketReport) {
+                when (it.deltaTicks) {
+                    in 0..0xFF -> buf[currOffset++] = it.deltaTicks.toByte()
+                    else -> {
+                        buf.putShort(currOffset, it.deltaTicks)
+                        currOffset += 2
+                    }
                 }
             }
         }
@@ -255,7 +259,7 @@ class RtcpFbTccPacket(
     buffer: ByteArray,
     offset: Int,
     length: Int
-) : TransportLayerRtcpFbPacket(buffer, offset, length), Iterable<ReceivedPacket> {
+) : TransportLayerRtcpFbPacket(buffer, offset, length), Iterable<PacketReport> {
 
     /**
      * Because much of time this packet is one that we built (not one
@@ -272,7 +276,7 @@ class RtcpFbTccPacket(
         var last_chunk_: LastChunk,
         var num_seq_no_: Int,
         var last_timestamp_us_: Long,
-        val packets_: MutableList<ReceivedPacket>
+        val packets_: MutableList<PacketReport>
     )
 
     private val data: TccMemberData by lazy(LazyThreadSafetyMode.NONE) {
@@ -282,7 +286,7 @@ class RtcpFbTccPacket(
         val last_chunk_ = LastChunk()
         var num_seq_no_: Int = 0
         var last_timestamp_us_: Long = 0
-        val packets_ = mutableListOf<ReceivedPacket>()
+        val packets_ = mutableListOf<PacketReport>()
 
         val base_time_ticks_ = getReferenceTimeTicks(buffer, offset)
         val delta_sizes = mutableListOf<Int>()
@@ -315,18 +319,16 @@ class RtcpFbTccPacket(
                     throw Exception("Buffer overflow while parsing packet.")
                 }
                 when (delta_size) {
-                    0 -> {
-                        packets_.add(ReceivedPacket(seq_no.value))
-                    }
+                    0 -> packets_.add(UnreceivedPacketReport(seq_no.value))
                     1 -> {
                         val delta = buffer[index]
-                        packets_.add(ReceivedPacket(seq_no.value, delta.toPositiveShort()))
+                        packets_.add(ReceivedPacketReport(seq_no.value, delta.toPositiveShort()))
                         last_timestamp_us_ += delta * kDeltaScaleFactor
                         index += delta_size
                     }
                     2 -> {
                         val delta = buffer.getShortAsInt(index)
-                        packets_.add(ReceivedPacket(seq_no.value, delta.toShort()))
+                        packets_.add(ReceivedPacketReport(seq_no.value, delta.toShort()))
                         last_timestamp_us_ += delta * kDeltaScaleFactor
                         index += delta_size
                     }
@@ -341,9 +343,9 @@ class RtcpFbTccPacket(
             for (delta_size in delta_sizes) {
                 // Use delta sizes to detect if packet was received.
                 if (delta_size == 0) {
-                    packets_.add(ReceivedPacket(seq_no.value))
+                    packets_.add(UnreceivedPacketReport(seq_no.value))
                 } else {
-                    packets_.add(ReceivedPacket(seq_no.value, 0))
+                    packets_.add(ReceivedPacketReport(seq_no.value, 0))
                 }
                 seq_no += 1
             }
@@ -368,7 +370,7 @@ class RtcpFbTccPacket(
         set(value) {
             data.num_seq_no_ = value
         }
-    private val packets_: MutableList<ReceivedPacket>
+    private val packets_: MutableList<PacketReport>
         get() = data.packets_
     private var last_timestamp_us_: Long
         get() = data.last_timestamp_us_
@@ -387,7 +389,7 @@ class RtcpFbTccPacket(
     fun GetBaseTimeUs(): Long =
         base_time_ticks_ * kBaseScaleFactor
 
-    override fun iterator(): Iterator<ReceivedPacket> = packets_.iterator()
+    override fun iterator(): Iterator<PacketReport> = packets_.iterator()
 
     override fun clone(): RtcpFbTccPacket = RtcpFbTccPacket(cloneBuffer(0), 0, length)
 

--- a/src/main/kotlin/org/jitsi/rtp/rtcp/rtcpfb/transport_layer_fb/tcc/RtcpFbTccPacket.kt
+++ b/src/main/kotlin/org/jitsi/rtp/rtcp/rtcpfb/transport_layer_fb/tcc/RtcpFbTccPacket.kt
@@ -48,7 +48,7 @@ class UnreceivedPacketReport(seqNum: Int) : PacketReport(seqNum)
 typealias DeltaSize = Int
 
 class ReceivedPacketReport(seqNum: Int, val deltaTicks: Short) : PacketReport(seqNum) {
-    val deltaTicksDuration: Duration
+    val deltaDuration: Duration
         get() = Duration.of(deltaTicks * 250L, ChronoUnit.MICROS)
 }
 

--- a/src/main/kotlin/org/jitsi/rtp/rtcp/rtcpfb/transport_layer_fb/tcc/RtcpFbTccPacket.kt
+++ b/src/main/kotlin/org/jitsi/rtp/rtcp/rtcpfb/transport_layer_fb/tcc/RtcpFbTccPacket.kt
@@ -16,6 +16,8 @@
 
 package org.jitsi.rtp.rtcp.rtcpfb.transport_layer_fb.tcc
 
+import java.time.Duration
+import java.time.temporal.ChronoUnit
 import org.jitsi.rtp.extensions.bytearray.put3Bytes
 import org.jitsi.rtp.extensions.bytearray.putShort
 import org.jitsi.rtp.extensions.unsigned.toPositiveLong
@@ -45,7 +47,10 @@ class UnreceivedPacketReport(seqNum: Int) : PacketReport(seqNum)
 // Valid values are 0 (packet wasn't received), 1 or 2.
 typealias DeltaSize = Int
 
-class ReceivedPacketReport(seqNum: Int, val deltaTicks: Short) : PacketReport(seqNum)
+class ReceivedPacketReport(seqNum: Int, val deltaTicks: Short) : PacketReport(seqNum) {
+    val deltaTicksDuration: Duration
+        get() = Duration.of(deltaTicks * 250L, ChronoUnit.MICROS)
+}
 
 /**
  * This class is a port of TransportFeedback in

--- a/src/main/kotlin/org/jitsi/rtp/rtcp/rtcpfb/transport_layer_fb/tcc/RtcpFbTccPacket.kt
+++ b/src/main/kotlin/org/jitsi/rtp/rtcp/rtcpfb/transport_layer_fb/tcc/RtcpFbTccPacket.kt
@@ -37,9 +37,7 @@ import org.jitsi.rtp.util.get3BytesAsInt
 import org.jitsi.rtp.util.getByteAsInt
 import org.jitsi.rtp.util.getShortAsInt
 
-open class PacketReport(val seqNum: Int) {
-    operator fun component1(): Int = seqNum
-}
+open class PacketReport(val seqNum: Int)
 
 class UnreceivedPacketReport(seqNum: Int) : PacketReport(seqNum)
 
@@ -47,9 +45,7 @@ class UnreceivedPacketReport(seqNum: Int) : PacketReport(seqNum)
 // Valid values are 0 (packet wasn't received), 1 or 2.
 typealias DeltaSize = Int
 
-class ReceivedPacketReport(seqNum: Int, val deltaTicks: Short) : PacketReport(seqNum) {
-    operator fun component2(): Short = deltaTicks
-}
+class ReceivedPacketReport(seqNum: Int, val deltaTicks: Short) : PacketReport(seqNum)
 
 /**
  * This class is a port of TransportFeedback in

--- a/src/test/kotlin/org/jitsi/rtp/rtcp/rtcpfb/transport_layer_fb/tcc/RtcpFbTccPacketTest.kt
+++ b/src/test/kotlin/org/jitsi/rtp/rtcp/rtcpfb/transport_layer_fb/tcc/RtcpFbTccPacketTest.kt
@@ -167,5 +167,30 @@ class RtcpFbTccPacketTest : ShouldSpec() {
             rtcpFbTccPacketBuilder.SetBase(6227, 107784064)
             rtcpFbTccPacketBuilder.AddReceivedPacket(6228, 107784064) shouldBe true
         }
+        "Creating and parsing an RtcpFbTccPacket" {
+            "with missing packets" {
+                val kBaseSeqNo = 1000
+                val kBaseTimestampUs = 10000L
+                val rtcpFbTccPacketBuilder = RtcpFbTccPacketBuilder(
+                    rtcpHeader = RtcpHeaderBuilder(
+                        senderSsrc = 839852602
+                    ),
+                    mediaSourceSsrc = 2397376430,
+                    feedbackPacketSeqNum = 163
+                )
+                rtcpFbTccPacketBuilder.SetBase(kBaseSeqNo, kBaseTimestampUs)
+                rtcpFbTccPacketBuilder.AddReceivedPacket(kBaseSeqNo + 0, kBaseTimestampUs)
+                rtcpFbTccPacketBuilder.AddReceivedPacket(kBaseSeqNo + 3, kBaseTimestampUs + 2000)
+
+                val coded = rtcpFbTccPacketBuilder.build()
+
+                val packet = RtcpFbTccPacket(coded.buffer, coded.offset, coded.length)
+                val it = packet.iterator()
+                it.next().received shouldBe true
+                it.next().received shouldBe false
+                it.next().received shouldBe false
+                it.next().received shouldBe true
+            }
+        }
     }
 }

--- a/src/test/kotlin/org/jitsi/rtp/rtcp/rtcpfb/transport_layer_fb/tcc/RtcpFbTccPacketTest.kt
+++ b/src/test/kotlin/org/jitsi/rtp/rtcp/rtcpfb/transport_layer_fb/tcc/RtcpFbTccPacketTest.kt
@@ -22,6 +22,7 @@ import io.kotlintest.matchers.withClue
 import io.kotlintest.should
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.ShouldSpec
+import java.time.Duration
 import org.jitsi.rtp.rtcp.RtcpHeaderBuilder
 import org.jitsi.rtp.util.byteBufferOf
 
@@ -140,11 +141,11 @@ class RtcpFbTccPacketTest : ShouldSpec() {
                 should("parse the values correctly") {
                     rtcpFbTccPacket.forEach {
                         it should beInstanceOf<ReceivedPacketReport>()
-                        if (it is ReceivedPacketReport) {
-                            expectedTccRlePacketInfo shouldContainKey it.seqNum
-                            withClue("seqNum ${it.seqNum} deltaTicks") {
-                                it.deltaTicks shouldBe expectedTccRlePacketInfo[it.seqNum]
-                            }
+                        val recv = it as ReceivedPacketReport
+                        expectedTccRlePacketInfo shouldContainKey recv.seqNum
+                        withClue("seqNum ${recv.seqNum} deltaTicks") {
+                            recv.deltaTicks shouldBe expectedTccRlePacketInfo[recv.seqNum]
+                            recv.deltaDuration shouldBe Duration.ofNanos(recv.deltaTicks * 250 * 1000L)
                         }
                     }
                 }
@@ -154,11 +155,11 @@ class RtcpFbTccPacketTest : ShouldSpec() {
                 should("parse the values correctly") {
                     rtcpFbTccPacket.forEach {
                         it should beInstanceOf<ReceivedPacketReport>()
-                        if (it is ReceivedPacketReport) {
-                            expectedTccMixedChunkTypePacketInfo shouldContainKey it.seqNum
-                            withClue("seqNum ${it.seqNum} deltaTicks") {
-                                it.deltaTicks shouldBe expectedTccMixedChunkTypePacketInfo[it.seqNum]
-                            }
+                        val recv = it as ReceivedPacketReport
+                        expectedTccMixedChunkTypePacketInfo shouldContainKey recv.seqNum
+                        withClue("seqNum ${recv.seqNum} deltaTicks") {
+                            recv.deltaTicks shouldBe expectedTccMixedChunkTypePacketInfo[recv.seqNum]
+                            recv.deltaDuration shouldBe Duration.ofNanos(recv.deltaTicks * 250 * 1000L)
                         }
                     }
                 }

--- a/src/test/kotlin/org/jitsi/rtp/rtcp/rtcpfb/transport_layer_fb/tcc/RtcpFbTccPacketTest.kt
+++ b/src/test/kotlin/org/jitsi/rtp/rtcp/rtcpfb/transport_layer_fb/tcc/RtcpFbTccPacketTest.kt
@@ -16,8 +16,10 @@
 
 package org.jitsi.rtp.rtcp.rtcpfb.transport_layer_fb.tcc
 
+import io.kotlintest.matchers.beInstanceOf
 import io.kotlintest.matchers.maps.shouldContainKey
 import io.kotlintest.matchers.withClue
+import io.kotlintest.should
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.ShouldSpec
 import org.jitsi.rtp.rtcp.RtcpHeaderBuilder
@@ -136,10 +138,13 @@ class RtcpFbTccPacketTest : ShouldSpec() {
             "with RLE" {
                 val rtcpFbTccPacket = RtcpFbTccPacket(tccRleData.array(), tccRleData.arrayOffset(), tccRleData.limit())
                 should("parse the values correctly") {
-                    rtcpFbTccPacket.forEach { (seqNum, deltaTicks) ->
-                        expectedTccRlePacketInfo shouldContainKey seqNum
-                        withClue("seqNum $seqNum deltaTicks") {
-                            deltaTicks shouldBe expectedTccRlePacketInfo[seqNum]
+                    rtcpFbTccPacket.forEach {
+                        it should beInstanceOf<ReceivedPacketReport>()
+                        if (it is ReceivedPacketReport) {
+                            expectedTccRlePacketInfo shouldContainKey it.seqNum
+                            withClue("seqNum ${it.seqNum} deltaTicks") {
+                                it.deltaTicks shouldBe expectedTccRlePacketInfo[it.seqNum]
+                            }
                         }
                     }
                 }
@@ -147,10 +152,13 @@ class RtcpFbTccPacketTest : ShouldSpec() {
             "with mixed chunk types and a negative delta" {
                 val rtcpFbTccPacket = RtcpFbTccPacket(tccMixedChunkTypeData.array(), tccMixedChunkTypeData.arrayOffset(), tccMixedChunkTypeData.limit())
                 should("parse the values correctly") {
-                    rtcpFbTccPacket.forEach { (seqNum, recvTimestamp) ->
-                        expectedTccMixedChunkTypePacketInfo shouldContainKey seqNum
-                        withClue("seqNum $seqNum timestamp") {
-                            recvTimestamp shouldBe expectedTccMixedChunkTypePacketInfo[seqNum]
+                    rtcpFbTccPacket.forEach {
+                        it should beInstanceOf<ReceivedPacketReport>()
+                        if (it is ReceivedPacketReport) {
+                            expectedTccMixedChunkTypePacketInfo shouldContainKey it.seqNum
+                            withClue("seqNum ${it.seqNum} deltaTicks") {
+                                it.deltaTicks shouldBe expectedTccMixedChunkTypePacketInfo[it.seqNum]
+                            }
                         }
                     }
                 }
@@ -186,10 +194,10 @@ class RtcpFbTccPacketTest : ShouldSpec() {
 
                 val packet = RtcpFbTccPacket(coded.buffer, coded.offset, coded.length)
                 val it = packet.iterator()
-                it.next().received shouldBe true
-                it.next().received shouldBe false
-                it.next().received shouldBe false
-                it.next().received shouldBe true
+                it.next() should beInstanceOf<ReceivedPacketReport>()
+                it.next() should beInstanceOf<UnreceivedPacketReport>()
+                it.next() should beInstanceOf<UnreceivedPacketReport>()
+                it.next() should beInstanceOf<ReceivedPacketReport>()
             }
         }
     }

--- a/src/test/kotlin/org/jitsi/rtp/rtcp/rtcpfb/transport_layer_fb/tcc/RtcpFbTccPacketTest.kt
+++ b/src/test/kotlin/org/jitsi/rtp/rtcp/rtcpfb/transport_layer_fb/tcc/RtcpFbTccPacketTest.kt
@@ -141,11 +141,11 @@ class RtcpFbTccPacketTest : ShouldSpec() {
                 should("parse the values correctly") {
                     rtcpFbTccPacket.forEach {
                         it should beInstanceOf<ReceivedPacketReport>()
-                        val recv = it as ReceivedPacketReport
-                        expectedTccRlePacketInfo shouldContainKey recv.seqNum
-                        withClue("seqNum ${recv.seqNum} deltaTicks") {
-                            recv.deltaTicks shouldBe expectedTccRlePacketInfo[recv.seqNum]
-                            recv.deltaDuration shouldBe Duration.ofNanos(recv.deltaTicks * 250 * 1000L)
+                        it as ReceivedPacketReport
+                        expectedTccRlePacketInfo shouldContainKey it.seqNum
+                        withClue("seqNum ${it.seqNum} deltaTicks") {
+                            it.deltaTicks shouldBe expectedTccRlePacketInfo[it.seqNum]
+                            it.deltaDuration shouldBe Duration.ofNanos(it.deltaTicks * 250 * 1000L)
                         }
                     }
                 }
@@ -155,11 +155,11 @@ class RtcpFbTccPacketTest : ShouldSpec() {
                 should("parse the values correctly") {
                     rtcpFbTccPacket.forEach {
                         it should beInstanceOf<ReceivedPacketReport>()
-                        val recv = it as ReceivedPacketReport
-                        expectedTccMixedChunkTypePacketInfo shouldContainKey recv.seqNum
-                        withClue("seqNum ${recv.seqNum} deltaTicks") {
-                            recv.deltaTicks shouldBe expectedTccMixedChunkTypePacketInfo[recv.seqNum]
-                            recv.deltaDuration shouldBe Duration.ofNanos(recv.deltaTicks * 250 * 1000L)
+                        it as ReceivedPacketReport
+                        expectedTccMixedChunkTypePacketInfo shouldContainKey it.seqNum
+                        withClue("seqNum ${it.seqNum} deltaTicks") {
+                            it.deltaTicks shouldBe expectedTccMixedChunkTypePacketInfo[it.seqNum]
+                            it.deltaDuration shouldBe Duration.ofNanos(it.deltaTicks * 250 * 1000L)
                         }
                     }
                 }


### PR DESCRIPTION
Add API reporting non-received packets in RtcpFbTccPacket: changes for the bandwidth estimation rework.

This goes along with https://github.com/jitsi/jitsi-media-transform/pull/130 and https://github.com/jitsi/jitsi-videobridge/pull/936.