### PR TITLE
make RtcpSrPacket#reportBlocks field non-lazy

### DIFF
--- a/src/main/kotlin/org/jitsi/rtp/rtcp/RtcpSrPacket.kt
+++ b/src/main/kotlin/org/jitsi/rtp/rtcp/RtcpSrPacket.kt
@@ -136,11 +136,11 @@ class RtcpSrPacket(
 
     val senderInfo: SenderInfo by lazy { SenderInfo() }
 
-    val reportBlocks: List<RtcpReportBlock> by lazy {
-        (0 until reportCount).map {
-            RtcpReportBlock.fromBuffer(buffer, offset + REPORT_BLOCKS_OFFSET + it * RtcpReportBlock.SIZE_BYTES)
-        }.toList()
-    }
+    val reportBlocks: List<RtcpReportBlock>
+        get() =
+            (0 until reportCount).map {
+                RtcpReportBlock.fromBuffer(buffer, offset + REPORT_BLOCKS_OFFSET + it * RtcpReportBlock.SIZE_BYTES)
+            }.toList()
 
     override fun clone(): RtcpSrPacket = RtcpSrPacket(cloneBuffer(0), 0, length)
 


### PR DESCRIPTION
computing this every time means we can set the reportCount field to 0 to
clear the report blocks (which we need to do when forwarding them in
JVB)

see https://github.com/jitsi/jitsi-media-transform/pull/146