### PR TITLE
Rtcp sr forwarding fix 2

### DIFF
--- a/src/main/kotlin/org/jitsi/rtp/rtcp/RtcpPacket.kt
+++ b/src/main/kotlin/org/jitsi/rtp/rtcp/RtcpPacket.kt
@@ -50,9 +50,8 @@ abstract class RtcpPacket(
         get() = RtcpHeader.hasPadding(buffer, offset)
         set(value) = RtcpHeader.setPadding(buffer, offset, value)
 
-    var reportCount: Int
+    val reportCount: Int
         get() = RtcpHeader.getReportCount(buffer, offset)
-        set(value) = RtcpHeader.setReportCount(buffer, offset, value)
 
     var packetType: Int
         get() = RtcpHeader.getPacketType(buffer, offset)

--- a/src/main/kotlin/org/jitsi/rtp/rtcp/RtcpSrPacket.kt
+++ b/src/main/kotlin/org/jitsi/rtp/rtcp/RtcpSrPacket.kt
@@ -144,6 +144,22 @@ class RtcpSrPacket(
 
     override fun clone(): RtcpSrPacket = RtcpSrPacket(cloneBuffer(0), 0, length)
 
+    fun cloneWithoutReportBlocks(): RtcpSrPacket {
+        return RtcpSrPacketBuilder(
+            rtcpHeader = RtcpHeaderBuilder(
+                reportCount = 0,
+                senderSsrc = this.senderSsrc
+            ),
+            senderInfo = SenderInfoBuilder(
+                ntpTimestampMsw = this.senderInfo.ntpTimestampMsw,
+                ntpTimestampLsw = this.senderInfo.ntpTimestampLsw,
+                rtpTimestamp = this.senderInfo.rtpTimestamp,
+                sendersPacketCount = this.senderInfo.sendersPacketCount,
+                sendersOctetCount = this.senderInfo.sendersOctetCount
+            )
+        ).build()
+    }
+
     // SenderInfo is defined differently so that we can scope these variables under a the 'senderInfo'
     // member here.  Is there a better way?
     inner class SenderInfo {

--- a/src/test/kotlin/org/jitsi/rtp/rtcp/RtcpSrPacketTest.kt
+++ b/src/test/kotlin/org/jitsi/rtp/rtcp/RtcpSrPacketTest.kt
@@ -19,6 +19,7 @@ package org.jitsi.rtp.rtcp
 import io.kotlintest.IsolationMode
 import io.kotlintest.matchers.collections.shouldHaveSize
 import io.kotlintest.shouldBe
+import io.kotlintest.shouldNotBe
 import io.kotlintest.specs.ShouldSpec
 import java.nio.ByteBuffer
 import org.jitsi.rtp.util.byteBufferOf
@@ -115,6 +116,38 @@ internal class RtcpSrPacketTest : ShouldSpec() {
                     // TODO: verify report block parse
 //                    srPacket.reportBlocks[0] shouldBe reportBlock1
 //                    srPacket.reportBlocks[1] shouldBe reportBlock2
+                }
+            }
+            "cloneWithoutReportBlocks" {
+                "when there were report blocks" {
+                    val clone = srPacket.cloneWithoutReportBlocks()
+                    should("clone everything correctly") {
+                        clone.version shouldBe srPacket.version
+                        clone.hasPadding shouldBe srPacket.hasPadding
+                        clone.reportCount shouldBe 0
+                        clone.packetType shouldBe srPacket.packetType
+                        clone.length shouldBe RtcpHeader.SIZE_BYTES + SenderInfoParser.SIZE_BYTES
+                        clone.senderSsrc shouldBe srPacket.senderSsrc
+                        clone.buffer shouldNotBe srPacket.buffer
+                    }
+                }
+                "when there were no report blocks" {
+                    val srPacketNoReportBlocks = RtcpSrPacketBuilder(
+                        RtcpHeaderBuilder(
+                            senderSsrc = 12345
+                        ),
+                        expectedSenderInfo
+                    ).build()
+                    val clone = srPacketNoReportBlocks.cloneWithoutReportBlocks()
+                    should("clone everything correctly") {
+                        clone.version shouldBe srPacket.version
+                        clone.hasPadding shouldBe srPacket.hasPadding
+                        clone.reportCount shouldBe 0
+                        clone.packetType shouldBe srPacket.packetType
+                        clone.length shouldBe RtcpHeader.SIZE_BYTES + SenderInfoParser.SIZE_BYTES
+                        clone.senderSsrc shouldBe srPacket.senderSsrc
+                        clone.buffer shouldNotBe srPacket.buffer
+                    }
                 }
             }
 //            "from explicit values" {


### PR DESCRIPTION
1) Make the `reportCount` field immutable: this is directly related to a var-length field, which is immutable, so this should match
2) Add a `cloneWithoutReportBlocks` method to `RtcpSrPacket` so we can clear them for forwarding