### PR TITLE
Optimize RtpUtils functions

### DIFF
--- a/src/main/kotlin/org/jitsi/rtp/util/RtpUtils.kt
+++ b/src/main/kotlin/org/jitsi/rtp/util/RtpUtils.kt
@@ -91,13 +91,10 @@ class RtpUtils {
          * TODO: since [Short] can fully represent sequence number deltas,
          *   change this to be the public API?
          */
-        private inline fun getSequenceNumberDeltaAsShort(a: Int, b: Int): Short {
-            val diff = a - b
+        private inline fun getSequenceNumberDeltaAsShort(a: Int, b: Int): Short =
             /* Coercing to short forces diff to the range -0x8000 - 0x7fff,
                which is what we want. */
-            val coerced = diff.toShort()
-            return coerced
-        }
+            (a - b).toShort()
 
         /**
          * Apply a delta to a given sequence number and return the result (taking
@@ -151,13 +148,10 @@ class RtpUtils {
          * TODO: since [Int] can fully represent timestamp deltas,
          *   change this to be the public API?
          */
-        private inline fun getTimestampDiffAsInt(a: Long, b: Long): Int {
-            val diff = a - b
+        private inline fun getTimestampDiffAsInt(a: Long, b: Long): Int =
             /* Coercing to int forces diff to the range -0x8000_0000 - 0x7fff_ffff,
-               which is what we want. */
-            val coerced = diff.toInt()
-            return coerced
-        }
+              which is what we want. */
+            (a - b).toInt()
 
         /**
          * Returns a sequence of Ints from olderSeqNum (exclusive) to newerSeqNum (exclusive),

--- a/src/main/kotlin/org/jitsi/rtp/util/RtpUtils.kt
+++ b/src/main/kotlin/org/jitsi/rtp/util/RtpUtils.kt
@@ -82,11 +82,20 @@ class RtpUtils {
          * @return the delta between two RTP sequence numbers (modulo 2^16).
          */
         @JvmStatic
-        fun getSequenceNumberDelta(a: Int, b: Int): Int {
+        fun getSequenceNumberDelta(a: Int, b: Int): Int =
+            getSequenceNumberDeltaAsShort(a, b).toInt()
+
+        /**
+         * Like [getSequenceNumberDelta], but returning the delta as a [Short].
+         *
+         * TODO: since [Short] can fully represent sequence number deltas,
+         *   change this to be the public API?
+         */
+        private inline fun getSequenceNumberDeltaAsShort(a: Int, b: Int): Short {
             val diff = a - b
             /* Coercing to short forces diff to the range -0x8000 - 0x7fff,
                which is what we want. */
-            val coerced = diff.toShort().toInt()
+            val coerced = diff.toShort()
             return coerced
         }
 
@@ -114,30 +123,40 @@ class RtpUtils {
 
         @JvmStatic
         fun isNewerSequenceNumberThan(a: Int, b: Int): Boolean =
-            getSequenceNumberDelta(a, b) > 0
+            getSequenceNumberDeltaAsShort(a, b) > 0
 
         @JvmStatic
         fun isOlderSequenceNumberThan(a: Int, b: Int): Boolean =
-            getSequenceNumberDelta(a, b) < 0
+            getSequenceNumberDeltaAsShort(a, b) < 0
 
         @JvmStatic
         fun isNewerTimestampThan(a: Long, b: Long): Boolean =
-            getTimestampDiff(a, b) > 0
+            getTimestampDiffAsInt(a, b) > 0
 
         @JvmStatic
         fun isOlderTimestampThan(a: Long, b: Long): Boolean =
-            getTimestampDiff(a, b) < 0
+            getTimestampDiffAsInt(a, b) < 0
 
         /**
          * Returns the difference between two RTP timestamps.
          * @return the difference between two RTP timestamps.
          */
         @JvmStatic
-        fun getTimestampDiff(a: Long, b: Long): Long {
+        fun getTimestampDiff(a: Long, b: Long): Long =
+            getTimestampDiffAsInt(a, b).toLong()
+
+        /**
+         * Returns the difference between two RTP timestamps as an [Int].
+         *
+         * TODO: since [Int] can fully represent timestamp deltas,
+         *   change this to be the public API?
+         */
+        private inline fun getTimestampDiffAsInt(a: Long, b: Long): Int {
             val diff = a - b
             /* Coercing to int forces diff to the range -0x8000_0000 - 0x7fff_ffff,
                which is what we want. */
-            return diff.toInt().toLong()
+            val coerced = diff.toInt()
+            return coerced
         }
 
         /**

--- a/src/main/kotlin/org/jitsi/rtp/util/RtpUtils.kt
+++ b/src/main/kotlin/org/jitsi/rtp/util/RtpUtils.kt
@@ -84,11 +84,10 @@ class RtpUtils {
         @JvmStatic
         fun getSequenceNumberDelta(a: Int, b: Int): Int {
             val diff = a - b
-            return when {
-                diff < -(1 shl 15) -> diff + (1 shl 16)
-                diff > (1 shl 15) -> diff - (1 shl 16)
-                else -> diff
-            }
+            /* Coercing to short forces diff to the range -0x8000 - 0x7fff,
+               which is what we want. */
+            val coerced = diff.toShort().toInt()
+            return coerced
         }
 
         /**
@@ -135,14 +134,10 @@ class RtpUtils {
          */
         @JvmStatic
         fun getTimestampDiff(a: Long, b: Long): Long {
-            var diff = a - b
-            if (diff < -0x8000_0000L) {
-                diff += 0x1_0000_0000L
-            } else if (diff > 0x8000_0000L) {
-                diff -= 0x1_0000_0000L
-            }
-
-            return diff
+            val diff = a - b
+            /* Coercing to int forces diff to the range -0x8000_0000 - 0x7fff_ffff,
+               which is what we want. */
+            return diff.toInt().toLong()
         }
 
         /**

--- a/src/test/kotlin/org/jitsi/rtp/rtp/RtpSequenceNumberTest.kt
+++ b/src/test/kotlin/org/jitsi/rtp/rtp/RtpSequenceNumberTest.kt
@@ -61,8 +61,8 @@ class RtpSequenceNumberTest : ShouldSpec() {
                 (RtpSequenceNumber(1) == RtpSequenceNumber(1)) shouldBe true
                 (RtpSequenceNumber(1) < RtpSequenceNumber(0)) shouldBe false
                 (RtpSequenceNumber(65534) < RtpSequenceNumber(0)) shouldBe true
-                (RtpSequenceNumber(32768) < RtpSequenceNumber(0)) shouldBe false
-                (RtpSequenceNumber(32769) < RtpSequenceNumber(0)) shouldBe true
+                (RtpSequenceNumber(32767) < RtpSequenceNumber(0)) shouldBe false
+                (RtpSequenceNumber(32768) < RtpSequenceNumber(0)) shouldBe true
             }
         }
         "rangeTo" {


### PR DESCRIPTION
This optimizes RtpUtils.getSequenceNumberDiff, RtpUtils.isOlderSequenceNumberThan, and related functions (and similarly for timestamps).  These are extremely heavily used in JVB.

Note this moves the RTP sequence number halfplane breakpoint by 1 -- 32768 is now less than 0, whereas previously it was greater.