### PR TITLE
Log more information when a compound RTCP packet contains invalid data

### DIFF
--- a/src/main/kotlin/org/jitsi/rtp/rtcp/CompoundRtcpPacket.kt
+++ b/src/main/kotlin/org/jitsi/rtp/rtcp/CompoundRtcpPacket.kt
@@ -69,5 +69,5 @@ class CompoundRtcpContainedInvalidDataException(
     compoundRtcpLength: Int,
     invalidDataOffset: Int
 ) : Exception("Compound RTCP contained invalid data.  Compound RTCP packet data is: " +
-    "${compoundRtcpBuf.toHex(compoundRtcpOffset, compoundRtcpLength)}. Invalid data " +
+    "${compoundRtcpBuf.toHex(compoundRtcpOffset, compoundRtcpLength)} Invalid data " +
     "started at offset ${invalidDataOffset - compoundRtcpOffset}")

--- a/src/main/kotlin/org/jitsi/rtp/rtcp/CompoundRtcpPacket.kt
+++ b/src/main/kotlin/org/jitsi/rtp/rtcp/CompoundRtcpPacket.kt
@@ -16,6 +16,7 @@
 
 package org.jitsi.rtp.rtcp
 
+import org.jitsi.rtp.extensions.bytearray.toHex
 import org.jitsi.rtp.util.BufferPool
 
 class CompoundRtcpPacket(
@@ -33,7 +34,11 @@ class CompoundRtcpPacket(
             var currOffset = offset
             val rtcpPackets = mutableListOf<RtcpPacket>()
             while (bytesRemaining >= RtcpHeader.SIZE_BYTES) {
-                val rtcpPacket = RtcpPacket.parse(buffer, currOffset, bytesRemaining)
+                val rtcpPacket = try {
+                    parse(buffer, currOffset, bytesRemaining)
+                } catch (e: InvalidRtcpException) {
+                    throw CompoundRtcpContainedInvalidDataException(buffer, offset, length, currOffset)
+                }
                 rtcpPackets.add(rtcpPacket)
                 currOffset += rtcpPacket.length
                 bytesRemaining -= rtcpPacket.length
@@ -57,3 +62,12 @@ class CompoundRtcpPacket(
 
     override fun clone(): RtcpPacket = CompoundRtcpPacket(cloneBuffer(0), 0, length)
 }
+
+class CompoundRtcpContainedInvalidDataException(
+    compoundRtcpBuf: ByteArray,
+    compoundRtcpOffset: Int,
+    compoundRtcpLength: Int,
+    invalidDataOffset: Int
+) : Exception("Compound RTCP contained invalid data.  Compound RTCP packet data is: " +
+    "${compoundRtcpBuf.toHex(compoundRtcpOffset, compoundRtcpLength)}. Invalid data " +
+    "started at offset ${invalidDataOffset - compoundRtcpOffset}")

--- a/src/main/kotlin/org/jitsi/rtp/rtcp/CompoundRtcpPacket.kt
+++ b/src/main/kotlin/org/jitsi/rtp/rtcp/CompoundRtcpPacket.kt
@@ -37,7 +37,7 @@ class CompoundRtcpPacket(
                 val rtcpPacket = try {
                     RtcpPacket.parse(buffer, currOffset, bytesRemaining)
                 } catch (e: InvalidRtcpException) {
-                    throw CompoundRtcpContainedInvalidDataException(buffer, offset, length, currOffset)
+                    throw CompoundRtcpContainedInvalidDataException(buffer, offset, length, currOffset, e.reason)
                 }
                 rtcpPackets.add(rtcpPacket)
                 currOffset += rtcpPacket.length
@@ -67,7 +67,8 @@ class CompoundRtcpContainedInvalidDataException(
     compoundRtcpBuf: ByteArray,
     compoundRtcpOffset: Int,
     compoundRtcpLength: Int,
-    invalidDataOffset: Int
+    invalidDataOffset: Int,
+    invalidDataReason: String
 ) : Exception("Compound RTCP contained invalid data.  Compound RTCP packet data is: " +
     "${compoundRtcpBuf.toHex(compoundRtcpOffset, compoundRtcpLength)} Invalid data " +
-    "started at offset ${invalidDataOffset - compoundRtcpOffset}")
+    "started at offset ${invalidDataOffset - compoundRtcpOffset} and failed due to '$invalidDataReason'")

--- a/src/main/kotlin/org/jitsi/rtp/rtcp/CompoundRtcpPacket.kt
+++ b/src/main/kotlin/org/jitsi/rtp/rtcp/CompoundRtcpPacket.kt
@@ -35,7 +35,7 @@ class CompoundRtcpPacket(
             val rtcpPackets = mutableListOf<RtcpPacket>()
             while (bytesRemaining >= RtcpHeader.SIZE_BYTES) {
                 val rtcpPacket = try {
-                    parse(buffer, currOffset, bytesRemaining)
+                    RtcpPacket.parse(buffer, currOffset, bytesRemaining)
                 } catch (e: InvalidRtcpException) {
                     throw CompoundRtcpContainedInvalidDataException(buffer, offset, length, currOffset)
                 }

--- a/src/main/kotlin/org/jitsi/rtp/rtcp/RtcpPacket.kt
+++ b/src/main/kotlin/org/jitsi/rtp/rtcp/RtcpPacket.kt
@@ -98,5 +98,5 @@ abstract class RtcpPacket(
     }
 }
 
-class InvalidRtcpException(buf: ByteArray, offset: Int, reason: String) :
+class InvalidRtcpException(buf: ByteArray, offset: Int, val reason: String) :
     Exception("Invalid RTCP packet: $reason: ${buf.toHex(offset, RtcpHeader.SIZE_BYTES)}")


### PR DESCRIPTION
An example exception looks like this:
```
org.jitsi.rtp.rtcp.CompoundRtcpContainedInvalidDataException: Compound RTCP contained invalid data.  Compound RTCP packet data is: 81CB0001 00003039 00000000 00000000
00000000 00000000  Invalid data started at offset 8
```