### PR TITLE
fix the header length calculation

### DIFF
--- a/src/main/kotlin/org/jitsi/rtp/rtp/RtpHeader.kt
+++ b/src/main/kotlin/org/jitsi/rtp/rtp/RtpHeader.kt
@@ -143,8 +143,7 @@ class RtpHeader {
          */
         fun getTotalLength(buf: ByteArray, baseOffset: Int): Int {
             val length =
-                FIXED_HEADER_SIZE_BYTES
-                    + getCsrcCount(buf, baseOffset) * 4
+                FIXED_HEADER_SIZE_BYTES + getCsrcCount(buf, baseOffset) * 4
 
             val extLength = if (hasExtensions(buf, baseOffset)) {
                 // Length points to where the ext header would start

--- a/src/test/kotlin/org/jitsi/rtp/rtp/RtpHeaderTest.kt
+++ b/src/test/kotlin/org/jitsi/rtp/rtp/RtpHeaderTest.kt
@@ -193,5 +193,10 @@ class RtpHeaderTest : ShouldSpec() {
                 }
             }
         }
+        "total length" {
+            should("be correct") {
+                RtpHeader.getTotalLength(headerData, 0) shouldBe 28
+            }
+        }
     }
 }


### PR DESCRIPTION
previously, the "+ getCsrcCount(buf, baseOffset) * 4" on the next line
wasn't detected as part of the expression and was ignored