### PR TITLE
allow changing the ID of an existing header extension

### DIFF
--- a/src/main/kotlin/org/jitsi/rtp/rtp/RtpPacket.kt
+++ b/src/main/kotlin/org/jitsi/rtp/rtp/RtpPacket.kt
@@ -26,7 +26,6 @@ import org.jitsi.rtp.util.BufferPool
 import org.jitsi.rtp.util.getByteAsInt
 import org.jitsi.rtp.util.isPadding
 import org.jitsi.utils.observableWhenChanged
-import sun.plugin.dom.exception.InvalidStateException
 
 /**
  *
@@ -385,7 +384,7 @@ open class RtpPacket(
             }
             set(newId) {
                 if (currExtLength <= 0) {
-                    throw InvalidStateException("Can't set ID on header extension with no length")
+                    throw IllegalStateException("Can't set ID on header extension with no length")
                 }
                 HeaderExtensionHelpers.setId(newId, currExtBuffer, currExtOffset)
             }

--- a/src/main/kotlin/org/jitsi/rtp/rtp/RtpPacket.kt
+++ b/src/main/kotlin/org/jitsi/rtp/rtp/RtpPacket.kt
@@ -26,6 +26,7 @@ import org.jitsi.rtp.util.BufferPool
 import org.jitsi.rtp.util.getByteAsInt
 import org.jitsi.rtp.util.isPadding
 import org.jitsi.utils.observableWhenChanged
+import sun.plugin.dom.exception.InvalidStateException
 
 /**
  *
@@ -375,12 +376,18 @@ open class RtpPacket(
             currExtLength = nextHeaderExtLength
         }
 
-        val id: Int
+        var id: Int
             get() {
                 if (currExtLength <= 0) {
                     return -1
                 }
                 return HeaderExtensionHelpers.getId(currExtBuffer, currExtOffset)
+            }
+            set(newId) {
+                if (currExtLength <= 0) {
+                    throw InvalidStateException("Can't set ID on header extension wiith no length")
+                }
+                HeaderExtensionHelpers.setId(newId, currExtBuffer, currExtOffset)
             }
 
         val dataLengthBytes: Int

--- a/src/main/kotlin/org/jitsi/rtp/rtp/RtpPacket.kt
+++ b/src/main/kotlin/org/jitsi/rtp/rtp/RtpPacket.kt
@@ -385,7 +385,7 @@ open class RtpPacket(
             }
             set(newId) {
                 if (currExtLength <= 0) {
-                    throw InvalidStateException("Can't set ID on header extension wiith no length")
+                    throw InvalidStateException("Can't set ID on header extension with no length")
                 }
                 HeaderExtensionHelpers.setId(newId, currExtBuffer, currExtOffset)
             }

--- a/src/main/kotlin/org/jitsi/rtp/rtp/header_extensions/HeaderExtensionHelpers.kt
+++ b/src/main/kotlin/org/jitsi/rtp/rtp/header_extensions/HeaderExtensionHelpers.kt
@@ -20,6 +20,7 @@ import kotlin.experimental.and
 import org.jitsi.rtp.extensions.unsigned.toPositiveInt
 import org.jitsi.rtp.util.getShortAsInt
 import unsigned.ushr
+import kotlin.experimental.or
 
 class HeaderExtensionHelpers {
     companion object {
@@ -31,6 +32,12 @@ class HeaderExtensionHelpers {
 
         fun getId(buf: ByteArray, offset: Int): Int =
             ((buf.get(offset) and 0xF0.toByte()) ushr 4).toPositiveInt()
+
+        fun setId(id: Int, buf: ByteArray, offset: Int) {
+            // Clear the old extension ID
+            buf[offset] = buf[offset] and 0x0F
+            buf[offset] = buf[offset] or (id shl 4).toByte()
+        }
 
         /**
          * Return the entire size, in bytes, of the extension in [buf] whose header

--- a/src/test/kotlin/org/jitsi/rtp/rtp/RtpPacketTest.kt
+++ b/src/test/kotlin/org/jitsi/rtp/rtp/RtpPacketTest.kt
@@ -16,6 +16,7 @@
 
 package org.jitsi.rtp.rtp
 
+import io.kotlintest.IsolationMode
 import io.kotlintest.should
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldNotBe
@@ -31,6 +32,7 @@ import org.jitsi.test_helpers.matchers.haveSameFixedHeader
 import org.jitsi.test_helpers.matchers.haveSamePayload
 
 class RtpPacketTest : ShouldSpec() {
+    override fun isolationMode(): IsolationMode? = IsolationMode.InstancePerLeaf
 
     private val rtpHeaderWithExtensions = org.jitsi.rtp.extensions.bytearray.byteArrayOf(
         // V=2,P=false,X=true,CC=0,M=false,PT=111,SeqNum=5807
@@ -103,6 +105,14 @@ class RtpPacketTest : ShouldSpec() {
 
                 rtpPacket.payloadLength shouldBe dummyRtpPayload.size
                 rtpPacket.getPayload() should haveSameContentAs(UnparsedPacket(dummyRtpPayload))
+            }
+            should("allow changing the ID of a header extension") {
+                val ext = rtpPacket.getHeaderExtension(1)
+                ext shouldNotBe null
+                ext as RtpPacket.HeaderExtension
+                ext.id = 12
+                rtpPacket.getHeaderExtension(1) shouldBe null
+                rtpPacket.getHeaderExtension(12) shouldNotBe null
             }
         }
         "An RTP packet with header extensions with padding between them" {


### PR DESCRIPTION
this is a hack: it's costly to remove header extensions, so to 'remove'
them for clients who don't support them on a particular stream, we'll
just change the id to an unsignaled one which must be ignored.  consider
reverting this someday...