### PR TITLE
Use specialized observable property for wrapping Int and Long properties

### DIFF
--- a/src/main/kotlin/org/jitsi/rtp/rtp/RtpPacket.kt
+++ b/src/main/kotlin/org/jitsi/rtp/rtp/RtpPacket.kt
@@ -25,7 +25,8 @@ import org.jitsi.rtp.rtp.header_extensions.HeaderExtensionHelpers
 import org.jitsi.rtp.util.BufferPool
 import org.jitsi.rtp.util.getByteAsInt
 import org.jitsi.rtp.util.isPadding
-import org.jitsi.utils.observableWhenChanged
+import org.jitsi.utils.observableIntWhenChanged
+import org.jitsi.utils.observableLongWhenChanged
 
 /**
  *
@@ -82,19 +83,19 @@ open class RtpPacket(
      * delegated properties, rather than re-reading them from the buffer every time.
      */
 
-    var payloadType: Int by observableWhenChanged(RtpHeader.getPayloadType(buffer, offset)) {
+    var payloadType: Int by observableIntWhenChanged(RtpHeader.getPayloadType(buffer, offset)) {
         _, _, newValue -> RtpHeader.setPayloadType(this.buffer, this.offset, newValue)
     }
 
-    var sequenceNumber: Int by observableWhenChanged(RtpHeader.getSequenceNumber(buffer, offset)) {
+    var sequenceNumber: Int by observableIntWhenChanged(RtpHeader.getSequenceNumber(buffer, offset)) {
         _, _, newValue -> RtpHeader.setSequenceNumber(this.buffer, this.offset, newValue)
     }
 
-    var timestamp: Long by observableWhenChanged(RtpHeader.getTimestamp(buffer, offset)) {
+    var timestamp: Long by observableLongWhenChanged(RtpHeader.getTimestamp(buffer, offset)) {
         _, _, newValue -> RtpHeader.setTimestamp(this.buffer, this.offset, newValue)
     }
 
-    var ssrc: Long by observableWhenChanged(RtpHeader.getSsrc(buffer, offset)) {
+    var ssrc: Long by observableLongWhenChanged(RtpHeader.getSsrc(buffer, offset)) {
         _, _, newValue -> RtpHeader.setSsrc(this.buffer, this.offset, newValue)
     }
 


### PR DESCRIPTION
During memory profiling of `JVB 2` I've noticed excessive `java.lang.Integer` and `java.lang.Long` allocations came from generic `ObservableProperty` usage in `RtpPacket`, which could be easily avoided by using type specializations of property wrappers I've added to https://github.com/jitsi/jitsi-utils/pull/56.