### PR TITLE
Avoid ObservableProperty for primitive type fields in RtpPacket.

### DIFF
--- a/src/main/kotlin/org/jitsi/rtp/rtp/RtpPacket.kt
+++ b/src/main/kotlin/org/jitsi/rtp/rtp/RtpPacket.kt
@@ -86,6 +86,7 @@ open class RtpPacket(
         set(newValue) {
             if (newValue != _payloadType) {
                 RtpHeader.setPayloadType(this.buffer, this.offset, newValue)
+                _payloadType = newValue
             }
         }
 
@@ -95,6 +96,7 @@ open class RtpPacket(
         set(newValue) {
             if (newValue != _sequenceNumber) {
                 RtpHeader.setSequenceNumber(this.buffer, this.offset, newValue)
+                _sequenceNumber = newValue
             }
         }
 
@@ -104,6 +106,7 @@ open class RtpPacket(
         set(newValue) {
             if (newValue != _timestamp) {
                 RtpHeader.setTimestamp(this.buffer, this.offset, newValue)
+                _timestamp = newValue
             }
         }
 
@@ -113,6 +116,7 @@ open class RtpPacket(
         set(newValue) {
             if (newValue != _ssrc) {
                 RtpHeader.setSsrc(this.buffer, this.offset, newValue)
+                _ssrc = newValue
             }
         }
 

--- a/src/main/kotlin/org/jitsi/rtp/rtp/RtpPacket.kt
+++ b/src/main/kotlin/org/jitsi/rtp/rtp/RtpPacket.kt
@@ -25,8 +25,6 @@ import org.jitsi.rtp.rtp.header_extensions.HeaderExtensionHelpers
 import org.jitsi.rtp.util.BufferPool
 import org.jitsi.rtp.util.getByteAsInt
 import org.jitsi.rtp.util.isPadding
-import org.jitsi.utils.observableWhenChanged
-
 /**
  *
  * https://tools.ietf.org/html/rfc3550#section-5.1
@@ -82,21 +80,41 @@ open class RtpPacket(
      * delegated properties, rather than re-reading them from the buffer every time.
      */
 
-    var payloadType: Int by observableWhenChanged(RtpHeader.getPayloadType(buffer, offset)) {
-        _, _, newValue -> RtpHeader.setPayloadType(this.buffer, this.offset, newValue)
-    }
+    private var _payloadType: Int = RtpHeader.getPayloadType(buffer, offset)
+    var payloadType: Int
+        get() = _payloadType
+        set(newValue) {
+            if (newValue != _payloadType) {
+                RtpHeader.setPayloadType(this.buffer, this.offset, newValue)
+            }
+        }
 
-    var sequenceNumber: Int by observableWhenChanged(RtpHeader.getSequenceNumber(buffer, offset)) {
-        _, _, newValue -> RtpHeader.setSequenceNumber(this.buffer, this.offset, newValue)
-    }
+    private var _sequenceNumber: Int = RtpHeader.getSequenceNumber(buffer, offset)
+    var sequenceNumber: Int
+        get() = _sequenceNumber
+        set(newValue) {
+            if (newValue != _sequenceNumber) {
+                RtpHeader.setSequenceNumber(this.buffer, this.offset, newValue)
+            }
+        }
 
-    var timestamp: Long by observableWhenChanged(RtpHeader.getTimestamp(buffer, offset)) {
-        _, _, newValue -> RtpHeader.setTimestamp(this.buffer, this.offset, newValue)
-    }
+    private var _timestamp: Long = RtpHeader.getTimestamp(buffer, offset)
+    var timestamp: Long
+        get() = _timestamp
+        set(newValue) {
+            if (newValue != _timestamp) {
+                RtpHeader.setTimestamp(this.buffer, this.offset, newValue)
+            }
+        }
 
-    var ssrc: Long by observableWhenChanged(RtpHeader.getSsrc(buffer, offset)) {
-        _, _, newValue -> RtpHeader.setSsrc(this.buffer, this.offset, newValue)
-    }
+    private var _ssrc: Long = RtpHeader.getSsrc(buffer, offset)
+    var ssrc: Long
+        get() = _ssrc
+        set(newValue) {
+            if (newValue != _ssrc) {
+                RtpHeader.setSsrc(this.buffer, this.offset, newValue)
+            }
+        }
 
     val csrcs: List<Long>
         get() = RtpHeader.getCsrcs(buffer, offset)


### PR DESCRIPTION
This PR obsoletes https://github.com/jitsi/jitsi-rtp/pull/78

With this PR there will be no `java.lang.Integer` and `java.lang.Long` boxed and put on heap from usage in `RtpPacket`.

This also eliminates an extra object for property itself.
This PR results in:
1. Enhanced data locality due to `Int` and `Long` are now stored in object itself;
1. Reduces number of temporary objects in heap, eliminating `java.lang.Integer`, `java.lang.Long` and `kotlin.properties.ObsevableProperty` and hence helping garbage collector by not producing garbage;
1. Reduces memory usage due to reducing number of objects in heap:
        - with this PR `2 Int` and `2 Long` fields are only consume `(4 + 8)*2 = 24` bytes,
        - before this PR `1` instance of `java.lang.Integer` consumed `20` bytes, `1` instance of `java.lang.Long` consumed `24` bytes, 1 instance of `ObservableProperty` consumed `40` bytes, resulting in `(20 + 24 + 40) * 2 = 168` bytes for `2` `Int` fields and `2` `Long` fields in packet.

More deeper analysis of object size in runtime is done in description of https://github.com/jitsi/jitsi-media-transform/pull/259