### PR TITLE
Add kotest-runner-console-jvm for IntelliJ kotest tests.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <version>1.0-SNAPSHOT</version>
 
     <properties>
-        <kotlin.version>1.3.71</kotlin.version>
+        <kotlin.version>1.3.72</kotlin.version>
         <kotest.version>4.1.3</kotest.version>
         <junit.version>5.2.0</junit.version>
         <jitsi.utils.version>1.0-58-gaa5a28f</jitsi.utils.version>
@@ -54,6 +54,12 @@
         <dependency>
             <groupId>io.kotest</groupId>
             <artifactId>kotest-assertions-core-jvm</artifactId>
+            <version>${kotest.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.kotest</groupId>
+            <artifactId>kotest-runner-console-jvm</artifactId>
             <version>${kotest.version}</version>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
Bump kotlin to latest 1.3.