### PR TITLE
update dependencies: spotbugs-maven-plugin to 4.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -235,7 +235,7 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>3.1.12.2</version>
+                <version>4.2.2</version>
                 <configuration>
                     <excludeFilterFile>spotbugs-exclude.xml</excludeFilterFile>
                     <includeTests>true</includeTests>


### PR DESCRIPTION
The existing version of the spotbugs-maven-plugin was causing build issues for me. It works fine with this latest version.