### PR TITLE
Support header extension removal

### DIFF
--- a/src/main/kotlin/org/jitsi/rtp/rtp/RtpPacket.kt
+++ b/src/main/kotlin/org/jitsi/rtp/rtp/RtpPacket.kt
@@ -187,8 +187,23 @@ open class RtpPacket(
         return null
     }
 
-    val hasExtensions: Boolean
+    var hasExtensions: Boolean
         get() = pendingHeaderExtensions?.isNotEmpty() ?: hasEncodedExtensions
+        set(value) {
+            val p = pendingHeaderExtensions
+            if (p != null) {
+                if (value && p.isEmpty()) {
+                    throw java.lang.IllegalStateException(
+                        "Cannot set hasExtensions to true with empty pending extensions"
+                    )
+                }
+                if (!value) {
+                    p.clear()
+                }
+            } else {
+                hasEncodedExtensions = value
+            }
+        }
 
     fun getHeaderExtension(extensionId: Int): HeaderExtension? {
         val activeHeaderExtensions = pendingHeaderExtensions?.iterator() ?: encodedHeaderExtensions

--- a/src/main/kotlin/org/jitsi/rtp/rtp/RtpPacket.kt
+++ b/src/main/kotlin/org/jitsi/rtp/rtp/RtpPacket.kt
@@ -294,6 +294,7 @@ open class RtpPacket(
         // We get this early, before we modify the buffer.
         val currHeaderLength = headerLength
         val currPayloadLength = payloadLength
+        val currPaddingSize = paddingSize
         val baseHeaderLength = RtpHeader.FIXED_HEADER_SIZE_BYTES + csrcCount * 4
 
         val newExtHeaderLength = if (pendingHeaderExtensions.isEmpty()) {
@@ -305,7 +306,7 @@ open class RtpPacket(
         }
 
         val newHeaderLength = baseHeaderLength + newExtHeaderLength
-        val newPacketLength = newHeaderLength + currPayloadLength
+        val newPacketLength = newHeaderLength + currPayloadLength + currPaddingSize
 
         val newPayloadOffset: Int
         val newBuffer = if (buffer.size >= (newPacketLength + BYTES_TO_LEAVE_AT_END_OF_PACKET)) {

--- a/src/main/kotlin/org/jitsi/rtp/rtp/RtpPacket.kt
+++ b/src/main/kotlin/org/jitsi/rtp/rtp/RtpPacket.kt
@@ -218,22 +218,16 @@ open class RtpPacket(
      * Removes the header extension (or all header extensions) with the given ID.
      */
     fun removeHeaderExtension(id: Int) {
-        if (pendingHeaderExtensions == null) {
-            createPendingHeaderExtensions { h -> h.id != id }
-        } else {
-            pendingHeaderExtensions!!.removeIf { h -> h.id == id }
-        }
+        pendingHeaderExtensions?.removeIf { h -> h.id == id }
+            ?: createPendingHeaderExtensions { h -> h.id != id }
     }
 
     /**
      * Removes all header extensions except those with ID values in [retain]
      */
     fun removeHeaderExtensionsExcept(retain: Set<Int>) {
-        if (pendingHeaderExtensions == null) {
-            createPendingHeaderExtensions { h -> retain.contains(h.id) }
-        } else {
-            pendingHeaderExtensions!!.removeIf { h -> !retain.contains(h.id) }
-        }
+        pendingHeaderExtensions?.removeIf { h -> !retain.contains(h.id) }
+            ?: createPendingHeaderExtensions { h -> retain.contains(h.id) }
     }
 
     /**
@@ -447,6 +441,10 @@ open class RtpPacket(
             get() = this@RtpPacket.buffer
     }
 
+    @SuppressFBWarnings(
+        value = ["EI_EXPOSE_REP"],
+        justification = "We intentionally expose the internal buffer."
+    )
     class PendingHeaderExtension(id: Int, extDataLength: Int) : HeaderExtension() {
         override val currExtBuffer = ByteArray(extDataLength + 1)
 

--- a/src/main/kotlin/org/jitsi/rtp/rtp/RtpPacket.kt
+++ b/src/main/kotlin/org/jitsi/rtp/rtp/RtpPacket.kt
@@ -201,13 +201,13 @@ open class RtpPacket(
         return null
     }
 
-    private fun createPendingHeaderExtensions(filter: ((HeaderExtension) -> Boolean)?) {
+    private fun createPendingHeaderExtensions(removeIf: ((HeaderExtension) -> Boolean)?) {
         if (pendingHeaderExtensions != null) {
             return
         }
         pendingHeaderExtensions = ArrayList<HeaderExtension>().also { l: ArrayList<HeaderExtension> ->
             encodedHeaderExtensions.forEach {
-                if (filter == null || filter(it)) {
+                if (removeIf == null || !removeIf(it)) {
                     l.add(PendingHeaderExtension(it))
                 }
             }
@@ -219,7 +219,7 @@ open class RtpPacket(
      */
     fun removeHeaderExtension(id: Int) {
         pendingHeaderExtensions?.removeIf { h -> h.id == id }
-            ?: createPendingHeaderExtensions { h -> h.id != id }
+            ?: createPendingHeaderExtensions { h -> h.id == id }
     }
 
     /**
@@ -227,7 +227,7 @@ open class RtpPacket(
      */
     fun removeHeaderExtensionsExcept(retain: Set<Int>) {
         pendingHeaderExtensions?.removeIf { h -> !retain.contains(h.id) }
-            ?: createPendingHeaderExtensions { h -> retain.contains(h.id) }
+            ?: createPendingHeaderExtensions { h -> !retain.contains(h.id) }
     }
 
     /**

--- a/src/main/kotlin/org/jitsi/rtp/rtp/RtpPacket.kt
+++ b/src/main/kotlin/org/jitsi/rtp/rtp/RtpPacket.kt
@@ -294,7 +294,6 @@ open class RtpPacket(
         // We get this early, before we modify the buffer.
         val currHeaderLength = headerLength
         val currPayloadLength = payloadLength
-        val currPaddingSize = paddingSize
         val baseHeaderLength = RtpHeader.FIXED_HEADER_SIZE_BYTES + csrcCount * 4
 
         val newExtHeaderLength = if (pendingHeaderExtensions.isEmpty()) {
@@ -306,7 +305,7 @@ open class RtpPacket(
         }
 
         val newHeaderLength = baseHeaderLength + newExtHeaderLength
-        val newPacketLength = newHeaderLength + currPayloadLength + currPaddingSize
+        val newPacketLength = newHeaderLength + currPayloadLength
 
         val newPayloadOffset: Int
         val newBuffer = if (buffer.size >= (newPacketLength + BYTES_TO_LEAVE_AT_END_OF_PACKET)) {
@@ -340,7 +339,7 @@ open class RtpPacket(
             var off = newOffset + baseHeaderLength
             // Write the header extension
             newBuffer.putShort(off, 0xBEDE.toShort())
-            newBuffer.putShort(off + 2, (newExtHeaderLength / 4).toShort())
+            newBuffer.putShort(off + 2, ((newExtHeaderLength - RtpHeader.EXT_HEADER_SIZE_BYTES) / 4).toShort())
             off += 4
             // Write pending header extension elements
             pendingHeaderExtensions.forEach { h ->

--- a/src/main/kotlin/org/jitsi/rtp/rtp/RtpPacket.kt
+++ b/src/main/kotlin/org/jitsi/rtp/rtp/RtpPacket.kt
@@ -47,7 +47,8 @@ import org.jitsi.rtp.util.isPadding
  */
 @SuppressFBWarnings(
     value = ["EI_EXPOSE_REP2"],
-    justification = "We intentionally pass a reference to our buffer when using observableWhenChanged.")
+    justification = "We intentionally pass a reference to our buffer when using observableWhenChanged."
+)
 open class RtpPacket(
     buffer: ByteArray,
     offset: Int,
@@ -221,10 +222,10 @@ open class RtpPacket(
         // the exact number, and is relatively close (it may be off by a few
         // bytes due to padding)
         val maxRequiredLength = length +
-                (if (extensionBit) 0 else RtpHeader.EXT_HEADER_SIZE_BYTES) +
-                1 /* the 1-byte header of the extension element */ +
-                extDataLength +
-                3 /* padding */
+            (if (extensionBit) 0 else RtpHeader.EXT_HEADER_SIZE_BYTES) +
+            1 /* the 1-byte header of the extension element */ +
+            extDataLength +
+            3 /* padding */
 
         val newPayloadOffset: Int
         val newBuffer = if (buffer.size >= (maxRequiredLength + BYTES_TO_LEAVE_AT_END_OF_PACKET)) {
@@ -279,7 +280,8 @@ open class RtpPacket(
             System.arraycopy(
                 buffer, offset,
                 newBuffer, 0,
-                newHeaderLength)
+                newHeaderLengt
+            )
         }
 
         if (!extensionBit) {
@@ -356,14 +358,16 @@ open class RtpPacket(
                 return 0
             }
             return HeaderExtensionHelpers.getExtensionsTotalLength(
-                buffer, offset + RtpHeader.FIXED_HEADER_SIZE_BYTES + csrcCount * 4)
+                buffer, offset + RtpHeader.FIXED_HEADER_SIZE_BYTES + csrcCount * 4
+            )
         }
 
     override fun clone(): RtpPacket =
         RtpPacket(
             cloneBuffer(BYTES_TO_LEAVE_AT_START_OF_PACKET),
             BYTES_TO_LEAVE_AT_START_OF_PACKET,
-            length)
+            length
+        )
 
     override fun toString(): String = with(StringBuilder()) {
         append("RtpPacket: ")
@@ -489,9 +493,9 @@ open class RtpPacket(
                 remainingLength = -1
             } else {
                 nextOffset = offset +
-                        RtpHeader.FIXED_HEADER_SIZE_BYTES +
-                        csrcCount * 4 +
-                        RtpHeader.EXT_HEADER_SIZE_BYTES
+                    RtpHeader.FIXED_HEADER_SIZE_BYTES +
+                    csrcCount * 4 +
+                    RtpHeader.EXT_HEADER_SIZE_BYTES
 
                 remainingLength = extLength
             }

--- a/src/main/kotlin/org/jitsi/rtp/rtp/RtpPacket.kt
+++ b/src/main/kotlin/org/jitsi/rtp/rtp/RtpPacket.kt
@@ -369,12 +369,11 @@ open class RtpPacket(
         }
 
     override fun clone(): RtpPacket {
-        encodeHeaderExtensions()
         return RtpPacket(
             cloneBuffer(BYTES_TO_LEAVE_AT_START_OF_PACKET),
             BYTES_TO_LEAVE_AT_START_OF_PACKET,
             length
-        )
+        ).also { if (pendingHeaderExtensions != null) it.pendingHeaderExtensions = ArrayList(pendingHeaderExtensions) }
     }
 
     override fun toString(): String = with(StringBuilder()) {

--- a/src/main/kotlin/org/jitsi/rtp/rtp/RtpPacket.kt
+++ b/src/main/kotlin/org/jitsi/rtp/rtp/RtpPacket.kt
@@ -340,6 +340,7 @@ open class RtpPacket(
             // Write padding
             while (off < newOffset + newHeaderLength) {
                 newBuffer[off] = 0
+                off++
             }
         }
 

--- a/src/test/kotlin/org/jitsi/rtp/rtp/RtpPacketTest.kt
+++ b/src/test/kotlin/org/jitsi/rtp/rtp/RtpPacketTest.kt
@@ -140,6 +140,8 @@ class RtpPacketTest : ShouldSpec() {
                     val rtpPacket = rtpPacketWithExtensions.clone()
                     val newExt = rtpPacket.addHeaderExtension(3, 2)
                     newExt.currExtBuffer.putShort(newExt.currExtOffset + 1, 0xDEAD.toShort())
+                    rtpPacket.encodeHeaderExtensions()
+
                     should("update the packet correctly") {
                         rtpPacket should haveSameFixedHeader(rtpPacketWithExtensions)
 
@@ -174,6 +176,8 @@ class RtpPacketTest : ShouldSpec() {
                     val rtpPacket = RtpPacket(buf, 0, rtpPacketWithExtensions.length)
                     val newExt = rtpPacket.addHeaderExtension(3, 2)
                     newExt.currExtBuffer.putShort(newExt.currExtOffset + 1, 0xDEAD.toShort())
+                    rtpPacket.encodeHeaderExtensions()
+
                     should("update the packet correctly") {
                         rtpPacket should haveSameFixedHeader(rtpPacketWithExtensions)
 
@@ -209,6 +213,8 @@ class RtpPacketTest : ShouldSpec() {
                     val rtpPacket = RtpPacket(buf, spaceOnTheLeft, rtpPacketWithExtensions.length)
                     val newExt = rtpPacket.addHeaderExtension(3, 2)
                     newExt.currExtBuffer.putShort(newExt.currExtOffset + 1, 0xDEAD.toShort())
+                    rtpPacket.encodeHeaderExtensions()
+
                     should("update the packet correctly") {
                         rtpPacket should haveSameFixedHeader(rtpPacketWithExtensions)
 
@@ -237,6 +243,8 @@ class RtpPacketTest : ShouldSpec() {
                     val rtpPacket = rtpPacketNoExtensions.clone()
                     val newExt = rtpPacket.addHeaderExtension(3, 2)
                     newExt.currExtBuffer.putShort(newExt.currExtOffset + 1, 0xDEAD.toShort())
+                    rtpPacket.encodeHeaderExtensions()
+
                     should("update the packet correctly") {
                         // The only difference in the fixed headers is the extension bit.
                         rtpPacket should haveSameFixedHeader(rtpPacketWithExtensions)
@@ -258,6 +266,8 @@ class RtpPacketTest : ShouldSpec() {
                     val rtpPacket = RtpPacket(buf, 0, rtpPacketNoExtensions.length)
                     val newExt = rtpPacket.addHeaderExtension(3, 2)
                     newExt.currExtBuffer.putShort(newExt.currExtOffset + 1, 0xDEAD.toShort())
+                    rtpPacket.encodeHeaderExtensions()
+
                     should("update the packet correctly") {
                         // The only difference in the fixed headers is the extension bit.
                         rtpPacket should haveSameFixedHeader(rtpPacketWithExtensions)
@@ -286,6 +296,8 @@ class RtpPacketTest : ShouldSpec() {
                     val rtpPacket = RtpPacket(buf, spaceOnTheLeft, rtpPacketNoExtensions.length)
                     val newExt = rtpPacket.addHeaderExtension(3, 2)
                     newExt.currExtBuffer.putShort(newExt.currExtOffset + 1, 0xDEAD.toShort())
+                    rtpPacket.encodeHeaderExtensions()
+
                     should("update the packet correctly") {
                         // The only difference in the fixed headers is the extension bit.
                         rtpPacket should haveSameFixedHeader(rtpPacketWithExtensions)

--- a/src/test/kotlin/org/jitsi/rtp/rtp/RtpPacketTest.kt
+++ b/src/test/kotlin/org/jitsi/rtp/rtp/RtpPacketTest.kt
@@ -365,12 +365,12 @@ class RtpPacketTest : ShouldSpec() {
                     ext as RtpPacket.HeaderExtension
                     ext.id shouldBe 1
                     ext.dataLengthBytes shouldBe 2
+                    // The offset is the start of the ext, add 1 to move past the header to get the data
                     ext.currExtBuffer.getShort(ext.currExtOffset + 1) shouldBe 0xFFFF.toShort()
 
                     val ext2 = rtpPacket.getHeaderExtension(2)
                     ext2 shouldBe null
 
-                    // The offset is the start of the ext, add 1 to move past the header to get the data
                     rtpPacket should haveSamePayload(rtpPacketNoExtensions)
                 }
             }

--- a/src/test/kotlin/org/jitsi/rtp/rtp/RtpPacketTest.kt
+++ b/src/test/kotlin/org/jitsi/rtp/rtp/RtpPacketTest.kt
@@ -18,14 +18,19 @@ package org.jitsi.rtp.rtp
 
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.comparables.shouldBeGreaterThanOrEqualTo
+import io.kotest.matchers.comparables.shouldBeLessThan
+import io.kotest.matchers.comparables.shouldBeLessThanOrEqualTo
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import org.jitsi.rtp.Packet
 import org.jitsi.rtp.UnparsedPacket
 import org.jitsi.rtp.extensions.bytearray.byteArrayOf
 import org.jitsi.rtp.extensions.bytearray.getShort
 import org.jitsi.rtp.extensions.bytearray.putShort
 import org.jitsi.rtp.extensions.unsigned.toPositiveInt
+import org.jitsi.rtp.util.BufferPool
 import org.jitsi.rtp.util.getByteAsInt
 import org.jitsi.test_helpers.matchers.getPayload
 import org.jitsi.test_helpers.matchers.haveSameContentAs
@@ -108,6 +113,7 @@ class RtpPacketTest : ShouldSpec() {
 
                 rtpPacket.payloadLength shouldBe dummyRtpPayload.size
                 rtpPacket.getPayload() should haveSameContentAs(UnparsedPacket(dummyRtpPayload))
+                rtpPacket.sanityCheck()
             }
             should("allow changing the ID of a header extension") {
                 val ext = rtpPacket.getHeaderExtension(1)
@@ -144,7 +150,11 @@ class RtpPacketTest : ShouldSpec() {
                     rtpPacket.encodeHeaderExtensions()
 
                     should("update the packet correctly") {
+                        rtpPacket.sanityCheck()
                         rtpPacket should haveSameFixedHeader(rtpPacketWithExtensions)
+
+                        rtpPacket.headerLength shouldBe
+                            RtpHeader.FIXED_HEADER_SIZE_BYTES + RtpHeader.EXT_HEADER_SIZE_BYTES + 8
 
                         val ext = rtpPacket.getHeaderExtension(1)
                         ext shouldNotBe null
@@ -180,7 +190,11 @@ class RtpPacketTest : ShouldSpec() {
                     rtpPacket.encodeHeaderExtensions()
 
                     should("update the packet correctly") {
+                        rtpPacket.sanityCheck()
                         rtpPacket should haveSameFixedHeader(rtpPacketWithExtensions)
+
+                        rtpPacket.headerLength shouldBe
+                            RtpHeader.FIXED_HEADER_SIZE_BYTES + RtpHeader.EXT_HEADER_SIZE_BYTES + 8
 
                         val ext = rtpPacket.getHeaderExtension(1)
                         ext shouldNotBe null
@@ -217,7 +231,11 @@ class RtpPacketTest : ShouldSpec() {
                     rtpPacket.encodeHeaderExtensions()
 
                     should("update the packet correctly") {
+                        rtpPacket.sanityCheck()
                         rtpPacket should haveSameFixedHeader(rtpPacketWithExtensions)
+
+                        rtpPacket.headerLength shouldBe
+                            RtpHeader.FIXED_HEADER_SIZE_BYTES + RtpHeader.EXT_HEADER_SIZE_BYTES + 8
 
                         val ext = rtpPacket.getHeaderExtension(1)
                         ext shouldNotBe null
@@ -247,8 +265,12 @@ class RtpPacketTest : ShouldSpec() {
                     rtpPacket.encodeHeaderExtensions()
 
                     should("update the packet correctly") {
+                        rtpPacket.sanityCheck()
                         // The only difference in the fixed headers is the extension bit.
                         rtpPacket should haveSameFixedHeader(rtpPacketWithExtensions)
+
+                        rtpPacket.headerLength shouldBe
+                            RtpHeader.FIXED_HEADER_SIZE_BYTES + RtpHeader.EXT_HEADER_SIZE_BYTES + 4
 
                         val ext = rtpPacket.getHeaderExtension(3)
                         ext shouldNotBe null
@@ -270,8 +292,12 @@ class RtpPacketTest : ShouldSpec() {
                     rtpPacket.encodeHeaderExtensions()
 
                     should("update the packet correctly") {
+                        rtpPacket.sanityCheck()
                         // The only difference in the fixed headers is the extension bit.
                         rtpPacket should haveSameFixedHeader(rtpPacketWithExtensions)
+
+                        rtpPacket.headerLength shouldBe
+                            RtpHeader.FIXED_HEADER_SIZE_BYTES + RtpHeader.EXT_HEADER_SIZE_BYTES + 4
 
                         val ext = rtpPacket.getHeaderExtension(3)
                         ext shouldNotBe null
@@ -300,8 +326,12 @@ class RtpPacketTest : ShouldSpec() {
                     rtpPacket.encodeHeaderExtensions()
 
                     should("update the packet correctly") {
+                        rtpPacket.sanityCheck()
                         // The only difference in the fixed headers is the extension bit.
                         rtpPacket should haveSameFixedHeader(rtpPacketWithExtensions)
+
+                        rtpPacket.headerLength shouldBe
+                            RtpHeader.FIXED_HEADER_SIZE_BYTES + RtpHeader.EXT_HEADER_SIZE_BYTES + 4
 
                         val ext = rtpPacket.getHeaderExtension(3)
                         ext shouldNotBe null
@@ -314,6 +344,38 @@ class RtpPacketTest : ShouldSpec() {
                         rtpPacket should haveSamePayload(rtpPacketNoExtensions)
                     }
                 }
+                context("in tight padding-only packets") {
+                    for (paddingLength in 0..255) {
+                        val length = paddingLength + RtpHeader.FIXED_HEADER_SIZE_BYTES
+                        val rtpPacket = PaddingOnlyPacket.create(length)
+
+                        val newExt = rtpPacket.addHeaderExtension(3, 2)
+                        newExt.currExtBuffer.putShort(newExt.currExtOffset + 1, 0xDEAD.toShort())
+                        rtpPacket.encodeHeaderExtensions()
+
+                        rtpPacket.sanityCheck()
+
+                        rtpPacket.headerLength shouldBe
+                            RtpHeader.FIXED_HEADER_SIZE_BYTES + RtpHeader.EXT_HEADER_SIZE_BYTES + 4
+
+                        val ext = rtpPacket.getHeaderExtension(3)
+                        ext shouldNotBe null
+                        ext as RtpPacket.HeaderExtension
+                        ext.id shouldBe 3
+                        ext.dataLengthBytes shouldBe 2
+                        // The offset is the start of the ext, add 1 to move past the header to get the data
+                        ext.currExtBuffer.getShort(ext.currExtOffset + 1) shouldBe 0xDEAD.toShort()
+
+                        // Payload length includes padding
+                        rtpPacket.payloadLength shouldBe length - RtpHeader.FIXED_HEADER_SIZE_BYTES
+                        rtpPacket.paddingSize shouldBe length - RtpHeader.FIXED_HEADER_SIZE_BYTES
+
+                        // This will have done a resize, so it should have left space at the end for the SRTP tag.
+                        rtpPacket.offset + rtpPacket.length +
+                            Packet.BYTES_TO_LEAVE_AT_END_OF_PACKET shouldBeLessThanOrEqualTo
+                            rtpPacket.buffer.size
+                    }
+                }
             }
         }
         context("Removing a header extension") {
@@ -323,7 +385,11 @@ class RtpPacketTest : ShouldSpec() {
                 rtpPacket.encodeHeaderExtensions()
 
                 should("update the packet correctly") {
+                    rtpPacket.sanityCheck()
                     rtpPacket should haveSameFixedHeader(rtpPacketWithExtensionsWithPaddingBetween)
+
+                    rtpPacket.headerLength shouldBe
+                        RtpHeader.FIXED_HEADER_SIZE_BYTES + RtpHeader.EXT_HEADER_SIZE_BYTES + 4
 
                     val ext = rtpPacket.getHeaderExtension(1)
                     ext shouldNotBe null
@@ -342,7 +408,10 @@ class RtpPacketTest : ShouldSpec() {
                 rtpPacket.encodeHeaderExtensions()
 
                 should("update the packet correctly") {
+                    rtpPacket.sanityCheck()
                     rtpPacket should haveSameFixedHeader(rtpPacketNoExtensions)
+
+                    rtpPacket.headerLength shouldBe RtpHeader.FIXED_HEADER_SIZE_BYTES
 
                     val ext = rtpPacket.getHeaderExtension(1)
                     ext shouldBe null
@@ -358,7 +427,11 @@ class RtpPacketTest : ShouldSpec() {
                 rtpPacket.encodeHeaderExtensions()
 
                 should("update the packet correctly") {
+                    rtpPacket.sanityCheck()
                     rtpPacket should haveSameFixedHeader(rtpPacketWithExtensionsWithPaddingBetween)
+
+                    rtpPacket.headerLength shouldBe
+                        RtpHeader.FIXED_HEADER_SIZE_BYTES + RtpHeader.EXT_HEADER_SIZE_BYTES + 4
 
                     val ext = rtpPacket.getHeaderExtension(1)
                     ext shouldNotBe null
@@ -381,7 +454,10 @@ class RtpPacketTest : ShouldSpec() {
                 rtpPacket.encodeHeaderExtensions()
 
                 should("update the packet correctly") {
+                    rtpPacket.sanityCheck()
                     rtpPacket should haveSameFixedHeader(rtpPacketNoExtensions)
+
+                    rtpPacket.headerLength shouldBe RtpHeader.FIXED_HEADER_SIZE_BYTES
 
                     val ext = rtpPacket.getHeaderExtension(1)
                     ext shouldBe null
@@ -396,7 +472,10 @@ class RtpPacketTest : ShouldSpec() {
                 rtpPacket.encodeHeaderExtensions()
 
                 should("update the packet correctly") {
+                    rtpPacket.sanityCheck()
                     rtpPacket should haveSameFixedHeader(rtpPacketNoExtensions)
+
+                    rtpPacket.headerLength shouldBe RtpHeader.FIXED_HEADER_SIZE_BYTES
 
                     val ext = rtpPacket.getHeaderExtension(1)
                     ext shouldBe null
@@ -415,7 +494,11 @@ class RtpPacketTest : ShouldSpec() {
                 rtpPacket.encodeHeaderExtensions()
 
                 should("update the packet correctly") {
+                    rtpPacket.sanityCheck()
                     rtpPacket should haveSameFixedHeader(rtpPacketWithExtensionsWithPaddingBetween)
+
+                    rtpPacket.headerLength shouldBe
+                        RtpHeader.FIXED_HEADER_SIZE_BYTES + RtpHeader.EXT_HEADER_SIZE_BYTES + 8
 
                     val ext = rtpPacket.getHeaderExtension(1)
                     ext shouldNotBe null
@@ -448,7 +531,11 @@ class RtpPacketTest : ShouldSpec() {
                 rtpPacket.encodeHeaderExtensions()
 
                 should("update the packet correctly") {
+                    rtpPacket.sanityCheck()
                     rtpPacket should haveSameFixedHeader(rtpPacketWithExtensionsWithPaddingBetween)
+
+                    rtpPacket.headerLength shouldBe
+                        RtpHeader.FIXED_HEADER_SIZE_BYTES + RtpHeader.EXT_HEADER_SIZE_BYTES + 4
 
                     val ext = rtpPacket.getHeaderExtension(1)
                     ext shouldBe null
@@ -469,4 +556,51 @@ class RtpPacketTest : ShouldSpec() {
             }
         }
     }
+}
+
+// This imitates PaddingVideoPacket in jmt
+class PaddingOnlyPacket private constructor(
+    buffer: ByteArray,
+    offset: Int,
+    length: Int
+) : RtpPacket(buffer, offset, length) {
+
+    override fun clone(): PaddingOnlyPacket =
+        throw NotImplementedError("clone() not supported for padding packets.")
+
+    companion object {
+        /**
+         * Creating a PaddingVideoPacket by directly grabbing a buffer in its
+         * ctor is problematic because we cannot clear the buffer we retrieve
+         * before calling the parent class' constructor.  Because the buffer
+         * may contain invalid data, any attempts to parse it by parent class(es)
+         * could fail, so we use a helper here instead
+         */
+        fun create(length: Int): PaddingOnlyPacket {
+            val buf = BufferPool.getArray(length)
+            // It's possible we the buffer we pulled from the pool already has
+            // data in it, and we won't be overwriting it with anything so clear
+            // out the data
+            buf.fill(0, 0, length)
+
+            return PaddingOnlyPacket(buf, 0, length).apply {
+                // Recalculate the header length now that we've zero'd everything out
+                // and set the fields
+                version = RtpHeader.VERSION
+                headerLength = RtpHeader.getTotalLength(buffer, offset)
+                paddingSize = payloadLength
+            }
+        }
+    }
+}
+
+fun RtpPacket.sanityCheck() {
+    offset shouldBeGreaterThanOrEqualTo 0
+    length shouldBeGreaterThanOrEqualTo 0
+    offset + length shouldBeLessThanOrEqualTo buffer.size
+    headerLength shouldBeLessThanOrEqualTo length
+    headerLength shouldBe RtpHeader.getTotalLength(buffer, offset)
+    payloadLength shouldBeLessThan length
+    headerLength + payloadLength shouldBe length
+    paddingSize shouldBeLessThanOrEqualTo payloadLength
 }

--- a/src/test/kotlin/org/jitsi/rtp/rtp/RtpPacketTest.kt
+++ b/src/test/kotlin/org/jitsi/rtp/rtp/RtpPacketTest.kt
@@ -315,5 +315,40 @@ class RtpPacketTest : ShouldSpec() {
                 }
             }
         }
+        context("Removing a header extension") {
+            context("when a header extension remains") {
+                val rtpPacket = rtpPacketWithExtensionsWithPaddingBetween.clone()
+                rtpPacket.removeHeaderExtension(2)
+                rtpPacket.encodeHeaderExtensions()
+
+                should("update the packet correctly") {
+                    rtpPacket should haveSameFixedHeader(rtpPacketWithExtensionsWithPaddingBetween)
+
+                    val ext = rtpPacket.getHeaderExtension(1)
+                    ext shouldNotBe null
+                    ext as RtpPacket.HeaderExtension
+                    ext.id shouldBe 1
+                    ext.dataLengthBytes shouldBe 2
+                    // The offset is the start of the ext, add 1 to move past the header to get the data
+                    ext.currExtBuffer.getShort(ext.currExtOffset + 1) shouldBe 0xFFFF.toShort()
+                    rtpPacket should haveSamePayload(rtpPacketNoExtensions)
+                }
+            }
+
+            context("when no header extension remains") {
+                val rtpPacket = rtpPacketWithExtensions.clone()
+                rtpPacket.removeHeaderExtension(1)
+                rtpPacket.encodeHeaderExtensions()
+
+                should("update the packet correctly") {
+                    rtpPacket should haveSameFixedHeader(rtpPacketNoExtensions)
+
+                    val ext = rtpPacket.getHeaderExtension(1)
+                    ext shouldBe null
+                    rtpPacket.hasExtensions shouldBe false
+                    rtpPacket should haveSamePayload(rtpPacketNoExtensions)
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Allow removal of RTP header extension elements; cache changes to header extensions until explicitly encoded.