### PR TITLE
Sdes header extension

### DIFF
--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -13,6 +13,7 @@
     <Bug pattern="SE_BAD_FIELD_STORE"/>
     <!-- False positives with lazy vals -->
     <Bug pattern="NP_NULL_ON_SOME_PATH"/>
+    <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>
   </Or>
 </Match>
 

--- a/src/main/kotlin/org/jitsi/rtp/rtp/header_extensions/SdesHeaderExtension.kt
+++ b/src/main/kotlin/org/jitsi/rtp/rtp/header_extensions/SdesHeaderExtension.kt
@@ -1,0 +1,36 @@
+package org.jitsi.rtp.rtp.header_extensions
+
+import org.jitsi.rtp.rtp.RtpPacket
+import org.jitsi.rtp.rtp.header_extensions.HeaderExtensionHelpers.Companion.getDataLengthBytes
+import org.jitsi.rtp.util.BufferPool
+import java.nio.charset.StandardCharsets
+
+/**
+ * https://datatracker.ietf.org/doc/html/rfc7941#section-4.1.1
+ * Note: this is only the One-Byte Format, because we don't support Two-Byte yet.
+ *  0                   1                   2                   3
+ *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |  ID   |  len  | SDES item text value ...                      |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ */
+class SdesHeaderExtension {
+    companion object {
+        const val DATA_OFFSET = 1
+
+        fun getTextValue(ext: RtpPacket.HeaderExtension): String =
+            getTextValue(ext.currExtBuffer, ext.currExtOffset)
+        fun setTextValue(ext: RtpPacket.HeaderExtension, sdesValue: String) =
+            setTextValue(ext.currExtBuffer, ext.currExtOffset, sdesValue)
+
+        fun getTextValue(buf: ByteArray, offset: Int): String {
+            val dataLength = getDataLengthBytes(buf, offset)
+            val copy = BufferPool.getArray(dataLength)
+            System.arraycopy(buf, offset + SdesHeaderExtension.DATA_OFFSET, copy, 0, dataLength)
+            return String(copy, StandardCharsets.US_ASCII)
+        }
+        fun setTextValue(buf: ByteArray, offset: Int, sdesValue: String) {
+            // TODO
+        }
+    }
+}

--- a/src/main/kotlin/org/jitsi/rtp/rtp/header_extensions/SdesHeaderExtension.kt
+++ b/src/main/kotlin/org/jitsi/rtp/rtp/header_extensions/SdesHeaderExtension.kt
@@ -32,9 +32,7 @@ class SdesHeaderExtension {
 
         private fun setTextValue(buf: ByteArray, offset: Int, sdesValue: String) {
             val dataLength = getDataLengthBytes(buf, offset)
-            if (dataLength < sdesValue.length) {
-                return
-            }
+            assert(dataLength == sdesValue.length) { "buffer size doesn't match SDES value length" }
             val array = sdesValue.toByteArray(StandardCharsets.US_ASCII)
             System.arraycopy(
                 array, 0, buf,

--- a/src/main/kotlin/org/jitsi/rtp/rtp/header_extensions/SdesHeaderExtension.kt
+++ b/src/main/kotlin/org/jitsi/rtp/rtp/header_extensions/SdesHeaderExtension.kt
@@ -23,13 +23,13 @@ class SdesHeaderExtension {
         fun setTextValue(ext: RtpPacket.HeaderExtension, sdesValue: String) =
             setTextValue(ext.currExtBuffer, ext.currExtOffset, sdesValue)
 
-        fun getTextValue(buf: ByteArray, offset: Int): String {
+        private fun getTextValue(buf: ByteArray, offset: Int): String {
             val dataLength = getDataLengthBytes(buf, offset)
             val copy = BufferPool.getArray(dataLength)
             System.arraycopy(buf, offset + SdesHeaderExtension.DATA_OFFSET, copy, 0, dataLength)
-            return String(copy, StandardCharsets.US_ASCII)
+            return String(copy, 0, dataLength, StandardCharsets.US_ASCII)
         }
-        fun setTextValue(buf: ByteArray, offset: Int, sdesValue: String) {
+        private fun setTextValue(buf: ByteArray, offset: Int, sdesValue: String) {
             // TODO
         }
     }

--- a/src/main/kotlin/org/jitsi/rtp/rtp/header_extensions/SdesHeaderExtension.kt
+++ b/src/main/kotlin/org/jitsi/rtp/rtp/header_extensions/SdesHeaderExtension.kt
@@ -39,14 +39,17 @@ class SdesHeaderExtension {
 
         private fun getTextValue(buf: ByteArray, offset: Int): String {
             val dataLength = getDataLengthBytes(buf, offset)
-            return String(buf, offset + SdesHeaderExtension.DATA_OFFSET, dataLength, StandardCharsets.UTF_8)
+            /* RFC 7941 says the value in RTP is UTF-8. But we use this for MID and RID values
+            * which are define for SDP in RFC 5888 and RFC 4566 as ASCII only. Thus we don't
+            * support UTF-8 to keep things simpler. */
+            return String(buf, offset + SdesHeaderExtension.DATA_OFFSET, dataLength, StandardCharsets.US_ASCII)
         }
 
         private fun setTextValue(buf: ByteArray, offset: Int, sdesValue: String) {
             val dataLength = getDataLengthBytes(buf, offset)
             assert(dataLength == sdesValue.length) { "buffer size doesn't match SDES value length" }
             System.arraycopy(
-                sdesValue.encodeToByteArray(), 0, buf,
+                sdesValue.toByteArray(StandardCharsets.US_ASCII), 0, buf,
                 offset + SdesHeaderExtension.DATA_OFFSET, sdesValue.length
             )
         }

--- a/src/main/kotlin/org/jitsi/rtp/rtp/header_extensions/SdesHeaderExtension.kt
+++ b/src/main/kotlin/org/jitsi/rtp/rtp/header_extensions/SdesHeaderExtension.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright @ 2021 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.jitsi.rtp.rtp.header_extensions
 
 import org.jitsi.rtp.rtp.RtpPacket

--- a/src/main/kotlin/org/jitsi/rtp/rtp/header_extensions/SdesHeaderExtension.kt
+++ b/src/main/kotlin/org/jitsi/rtp/rtp/header_extensions/SdesHeaderExtension.kt
@@ -17,7 +17,6 @@ package org.jitsi.rtp.rtp.header_extensions
 
 import org.jitsi.rtp.rtp.RtpPacket
 import org.jitsi.rtp.rtp.header_extensions.HeaderExtensionHelpers.Companion.getDataLengthBytes
-import org.jitsi.rtp.util.BufferPool
 import java.nio.charset.StandardCharsets
 
 /**

--- a/src/main/kotlin/org/jitsi/rtp/rtp/header_extensions/SdesHeaderExtension.kt
+++ b/src/main/kotlin/org/jitsi/rtp/rtp/header_extensions/SdesHeaderExtension.kt
@@ -29,8 +29,17 @@ class SdesHeaderExtension {
             System.arraycopy(buf, offset + SdesHeaderExtension.DATA_OFFSET, copy, 0, dataLength)
             return String(copy, 0, dataLength, StandardCharsets.US_ASCII)
         }
+
         private fun setTextValue(buf: ByteArray, offset: Int, sdesValue: String) {
-            // TODO
+            val dataLength = getDataLengthBytes(buf, offset)
+            if (dataLength < sdesValue.length) {
+                return
+            }
+            val array = sdesValue.toByteArray(StandardCharsets.US_ASCII)
+            System.arraycopy(
+                array, 0, buf,
+                offset + SdesHeaderExtension.DATA_OFFSET, sdesValue.length
+            )
         }
     }
 }

--- a/src/main/kotlin/org/jitsi/rtp/rtp/header_extensions/SdesHeaderExtension.kt
+++ b/src/main/kotlin/org/jitsi/rtp/rtp/header_extensions/SdesHeaderExtension.kt
@@ -40,17 +40,14 @@ class SdesHeaderExtension {
 
         private fun getTextValue(buf: ByteArray, offset: Int): String {
             val dataLength = getDataLengthBytes(buf, offset)
-            val copy = BufferPool.getArray(dataLength)
-            System.arraycopy(buf, offset + SdesHeaderExtension.DATA_OFFSET, copy, 0, dataLength)
-            return String(copy, 0, dataLength, StandardCharsets.US_ASCII)
+            return String(buf, offset + SdesHeaderExtension.DATA_OFFSET, dataLength, StandardCharsets.UTF_8)
         }
 
         private fun setTextValue(buf: ByteArray, offset: Int, sdesValue: String) {
             val dataLength = getDataLengthBytes(buf, offset)
             assert(dataLength == sdesValue.length) { "buffer size doesn't match SDES value length" }
-            val array = sdesValue.toByteArray(StandardCharsets.US_ASCII)
             System.arraycopy(
-                array, 0, buf,
+                sdesValue.encodeToByteArray(), 0, buf,
                 offset + SdesHeaderExtension.DATA_OFFSET, sdesValue.length
             )
         }

--- a/src/test/kotlin/org/jitsi/rtp/rtp/header_extensions/SdesHeaderExtensionTest.kt
+++ b/src/test/kotlin/org/jitsi/rtp/rtp/header_extensions/SdesHeaderExtensionTest.kt
@@ -45,14 +45,14 @@ class SdesHeaderExtensionTest : ShouldSpec() {
     private val rtpHeaderSimpleSdesExtension = byteArrayOf(
         // BEDE, length=1
         0xbe, 0xde, 0x00, 0x01,
-        // ExtId=1,Length=0(1 byte),Data=ASCII 1,Padding
+        // ExtId=1,Length=0(1 byte),Data='1',Padding
         0x10, 0x31, 0x00, 0x00
     )
 
     private val rtpHeaderMaxSdesExtension = byteArrayOf(
         // BEDE, length=5
         0xbe, 0xde, 0x00, 0x05,
-        // ExtId=1,Length=15(16 byte),Data=ASCII 'abcdefghijklmnop',Padding
+        // ExtId=15,Length=15(16 byte),Data='abcdefghijklmnop',Padding
         0xff, 0x61, 0x62, 0x63,
         0x64, 0x65, 0x66, 0x67,
         0x68, 0x69, 0x6a, 0x6b,

--- a/src/test/kotlin/org/jitsi/rtp/rtp/header_extensions/SdesHeaderExtensionTest.kt
+++ b/src/test/kotlin/org/jitsi/rtp/rtp/header_extensions/SdesHeaderExtensionTest.kt
@@ -18,7 +18,6 @@ package org.jitsi.rtp.rtp.header_extensions
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNot
 import io.kotest.matchers.shouldNotBe
 import org.jitsi.rtp.extensions.bytearray.byteArrayOf
 import org.jitsi.rtp.rtp.RtpPacket

--- a/src/test/kotlin/org/jitsi/rtp/rtp/header_extensions/SdesHeaderExtensionTest.kt
+++ b/src/test/kotlin/org/jitsi/rtp/rtp/header_extensions/SdesHeaderExtensionTest.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright @ 2021 - present 8x8, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jitsi.rtp.rtp.header_extensions
+
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNot
+import io.kotest.matchers.shouldNotBe
+import org.jitsi.rtp.extensions.bytearray.byteArrayOf
+import org.jitsi.rtp.rtp.RtpPacket
+
+class SdesHeaderExtensionTest : ShouldSpec() {
+    override fun isolationMode(): IsolationMode? = IsolationMode.InstancePerLeaf
+
+    private val rtpHeaderWithEmptyExtension = byteArrayOf(
+        // V=2,P=false,X=true,CC=0,M=false,PT=111,SeqNum=5807
+        0x90, 0x6f, 0x16, 0xaf,
+        // Timestamp: 1710483662
+        0x65, 0xf3, 0xe8, 0xce,
+        // SSRC: 1208951354
+        0x48, 0x0f, 0x22, 0x3a,
+    )
+
+    private val dummyRtpPayload = byteArrayOf(
+        0x42, 0x42, 0x42, 0x42,
+        0x42, 0x42, 0x42, 0x42,
+        0x42, 0x42, 0x42, 0x42,
+        0x42, 0x42, 0x42, 0x42,
+        0x42, 0x42, 0x42, 0x42
+    )
+
+    private val rtpHeaderSimpleSdesExtension = byteArrayOf(
+        // BEDE, length=1
+        0xbe, 0xde, 0x00, 0x01,
+        // ExtId=1,Length=0(1 byte),Data=ASCII 1,Padding
+        0x10, 0x31, 0x00, 0x00
+    )
+
+    private val rtpHeaderMaxSdesExtension = byteArrayOf(
+        // BEDE, length=5
+        0xbe, 0xde, 0x00, 0x05,
+        // ExtId=1,Length=15(16 byte),Data=ASCII 'abcdefghijklmnop',Padding
+        0xff, 0x61, 0x62, 0x63,
+        0x64, 0x65, 0x66, 0x67,
+        0x68, 0x69, 0x6a, 0x6b,
+        0x6c, 0x6d, 0x6e, 0x6f,
+        0x70, 0x00, 0x00, 0x00
+    )
+
+    private val simpleSdesHeaderExtension = RtpPacket(
+        rtpHeaderWithEmptyExtension +
+            rtpHeaderSimpleSdesExtension + dummyRtpPayload
+    )
+    private val maxLengthSdesHeaderExtension = RtpPacket(
+        rtpHeaderWithEmptyExtension +
+            rtpHeaderMaxSdesExtension + dummyRtpPayload
+    )
+
+    init {
+        context("RTP with simple SDES extension value 1") {
+            val rtpPacket = simpleSdesHeaderExtension
+            should("simple SDES should be parsed correctly") {
+                val sdesExt = rtpPacket.getHeaderExtension(1)
+                sdesExt shouldNotBe null
+                sdesExt as RtpPacket.HeaderExtension
+                sdesExt.id shouldBe 1
+                sdesExt.dataLengthBytes shouldBe 1
+                val payload = SdesHeaderExtension.getTextValue(sdesExt)
+                payload shouldBe "1"
+            }
+            should("allow changing the simple SDES value") {
+                val sdesExt = rtpPacket.getHeaderExtension(1)
+                sdesExt shouldNotBe null
+                sdesExt as RtpPacket.HeaderExtension
+                SdesHeaderExtension.setTextValue(sdesExt, "2")
+                val payload = SdesHeaderExtension.getTextValue(sdesExt)
+                payload shouldBe "2"
+            }
+        }
+        context("RTP with max len SDES extension value abcdefghijklmop") {
+            val rtpPacket = maxLengthSdesHeaderExtension
+            should("max length SDES should be parsed correctly") {
+                val sdesExt = rtpPacket.getHeaderExtension(15)
+                sdesExt shouldNotBe null
+                sdesExt as RtpPacket.HeaderExtension
+                sdesExt.id shouldBe 15
+                sdesExt.dataLengthBytes shouldBe 16
+                val payload = SdesHeaderExtension.getTextValue(sdesExt)
+                payload shouldBe "abcdefghijklmnop"
+            }
+            should("allow changing the max length SDES value") {
+                val sdesExt = rtpPacket.getHeaderExtension(15)
+                sdesExt shouldNotBe null
+                sdesExt as RtpPacket.HeaderExtension
+                SdesHeaderExtension.setTextValue(sdesExt, "ZYX23acj00yxzABC")
+                val payload = SdesHeaderExtension.getTextValue(sdesExt)
+                payload shouldBe "ZYX23acj00yxzABC"
+            }
+        }
+    }
+}


### PR DESCRIPTION
This adds support for SDES RTP header extensions, which is needed to support MID and RID values in RTP packets.