### PR TITLE
Fix ByteArray.toHex (do not read past the end of the array)

### DIFF
--- a/src/main/kotlin/org/jitsi/rtp/extensions/ByteArrayBuffer.kt
+++ b/src/main/kotlin/org/jitsi/rtp/extensions/ByteArrayBuffer.kt
@@ -16,30 +16,8 @@
 
 package org.jitsi.rtp.extensions
 
+import org.jitsi.rtp.extensions.bytearray.toHex
 import org.jitsi.utils.ByteArrayBuffer
 
 @JvmOverloads
-fun ByteArrayBuffer.toHex(maxBytes: Int = Int.MAX_VALUE): String {
-    val HEX_CHARS = "0123456789ABCDEF"
-
-    val numBytes = minOf(maxBytes, length, buffer.size - offset)
-
-    val sb = StringBuilder()
-    for (i in offset until offset + numBytes) {
-        val position = i - offset
-        if (position != 0) {
-            if (position % 16 == 0) {
-                sb.append("\n")
-            } else if (position % 4 == 0) {
-                sb.append(" ")
-            }
-        }
-        val byte: Int = buffer[i].toInt()
-        val firstIndex = (byte and 0xF0) shr 4
-        val secondIndex = byte and 0x0F
-        sb.append(HEX_CHARS[firstIndex])
-        sb.append(HEX_CHARS[secondIndex])
-    }
-
-    return sb.toString()
-}
+fun ByteArrayBuffer.toHex(maxBytes: Int = Int.MAX_VALUE) = buffer.toHex(offset, maxBytes.coerceAtMost(length))

--- a/src/main/kotlin/org/jitsi/rtp/extensions/bytearray/ByteArrayExtensions.kt
+++ b/src/main/kotlin/org/jitsi/rtp/extensions/bytearray/ByteArrayExtensions.kt
@@ -109,14 +109,18 @@ operator fun ByteArray.plus(other: ByteArray): ByteArray {
 
 private val HEX_CHARS = "0123456789ABCDEF".toCharArray()
 /**
- * Print the entire contents of the [ByteArray] as hex
- * digits
+ * Print the contents of the [ByteArray] as hex digits.
  */
-fun ByteArray.toHex(offset: Int = 0, length: Int = (size - offset)): String {
+fun ByteArray.toHex(
+    /** Offset to start at. */
+    offset: Int = 0,
+    /** Maximum number of elements to print. */
+    length: Int = (size - offset)
+): String {
     val result = StringBuffer()
     var position = 0
 
-    for (i in offset until (offset + length)) {
+    for (i in offset until (offset + length).coerceAtMost(size)) {
         val octet = get(i).toInt()
         val firstIndex = (octet and 0xF0).ushr(4)
         val secondIndex = octet and 0x0F

--- a/src/main/kotlin/org/jitsi/rtp/extensions/bytearray/ByteArrayExtensions.kt
+++ b/src/main/kotlin/org/jitsi/rtp/extensions/bytearray/ByteArrayExtensions.kt
@@ -118,20 +118,21 @@ fun ByteArray.toHex(
     length: Int = (size - offset)
 ): String {
     val result = StringBuffer()
-    var position = 0
 
     for (i in offset until (offset + length).coerceAtMost(size)) {
-        val octet = get(i).toInt()
-        val firstIndex = (octet and 0xF0).ushr(4)
-        val secondIndex = octet and 0x0F
+        val position = i - offset
+        if (position != 0) {
+            if (position % 16 == 0) {
+                result.append("\n")
+            } else if (position % 4 == 0) {
+                result.append(" ")
+            }
+        }
+        val byte: Int = this[i].toInt()
+        val firstIndex = (byte and 0xF0) shr 4
+        val secondIndex = byte and 0x0F
         result.append(HEX_CHARS[firstIndex])
         result.append(HEX_CHARS[secondIndex])
-        if ((position + 1) % 16 == 0) {
-            result.append("\n")
-        } else if ((position + 1) % 4 == 0) {
-            result.append(" ")
-        }
-        position++
     }
 
     return result.toString()


### PR DESCRIPTION
- fix: Do not print past the limits of the array.
- ref: Reuse ByteArray.toHex().
