### PR TITLE
Handle sequence number wrapping in NACK packets.

### DIFF
--- a/src/main/kotlin/org/jitsi/rtp/rtcp/rtcpfb/transport_layer_fb/RtcpFbNackPacket.kt
+++ b/src/main/kotlin/org/jitsi/rtp/rtcp/rtcpfb/transport_layer_fb/RtcpFbNackPacket.kt
@@ -148,7 +148,7 @@ private class NackBlock(
             val missingSeqNums = mutableListOf(packetId)
             for (shiftAmount in 0..15) {
                 if (((blp ushr shiftAmount) and 0x1) == 1) {
-                    missingSeqNums.add(packetId + shiftAmount + 1)
+                    missingSeqNums.add((packetId + shiftAmount + 1) and 0xffff)
                 }
             }
             return missingSeqNums


### PR DESCRIPTION
Also restore a commented-out NACK packet unit test.